### PR TITLE
Added QA-06.01

### DIFF
--- a/evaluation_plans/osps/quality/evaluations.go
+++ b/evaluation_plans/osps/quality/evaluations.go
@@ -176,7 +176,7 @@ func OSPS_QA_06() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
-			reusable_steps.NotImplemented,
+			hasOneOrMoreStatusChecks,
 		},
 	)
 


### PR DESCRIPTION
part of #27 

## Copilot notes

This pull request includes changes to the `evaluation_plans/osps/quality` package to improve the evaluation process by adding a new step for status checks and updating the evaluation plan accordingly. The most important changes are listed below:

### Evaluation Plan Updates:
* [`evaluation_plans/osps/quality/evaluations.go`](diffhunk://#diff-630c439bbec4698dc0690a239c3ae37f6e02ac1d7512a059b869c691ad4feeafL179-R179): Replaced the `reusable_steps.NotImplemented` step with the newly added `hasOneOrMoreStatusChecks` step in the `OSPS_QA_06` function.

### New Evaluation Step:
* [`evaluation_plans/osps/quality/steps.go`](diffhunk://#diff-92e8d099ffd444242904db17598cc32a556daba4a37a2e2d2b3e3deaa719cfe0R142-R164): Added the `hasOneOrMoreStatusChecks` function to verify if one or more status checks were run on the repository. This function extracts the status checks from the payload data and returns a passed or failed result based on their presence.