### PR TITLE
Add more specific/explicit reusable step for Github Terms of Service

### DIFF
--- a/evaluation_plans/osps/legal/evaluations.go
+++ b/evaluation_plans/osps/legal/evaluations.go
@@ -22,7 +22,7 @@ func OSPS_LE_01() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
-			reusable_steps.GithubBuiltIn,
+			reusable_steps.GithubTermsOfService,
 		},
 	)
 

--- a/evaluation_plans/reusable_steps/evaluations.go
+++ b/evaluation_plans/reusable_steps/evaluations.go
@@ -29,6 +29,10 @@ func GithubBuiltIn(payloadData interface{}, _ map[string]*layer4.Change) (result
 	return layer4.Passed, "This control is enforced by GitHub for all projects"
 }
 
+func GithubTermsOfService(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+	return layer4.Passed, "This control is satisfied by the GitHub Terms of Service"
+}
+
 func HasSecurityInsightsFile(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	payload, message := VerifyPayload(payloadData)
 	if message != "" {


### PR DESCRIPTION
This PR replaces the usage of the reusable step `GithubBuiltIn` in the evaluation of OSPS-LE-01.01 with a new, more descriptive reusable step `GithubTermsOfService`

This change is being made to add clarity both to the codebase but also to the user-facing message returned with the result of the control's evaluation.

See https://baseline.openssf.org/versions/2025-02-25#osps-le-0101 , specifically the recommendation language where we see

> Some version control systems, such as GitHub, may include this in the platform terms of service.