### PR TITLE
Basic implementation of QA-06.02 and QA-06.03

### DIFF
--- a/evaluation_plans/osps/quality/evaluations.go
+++ b/evaluation_plans/osps/quality/evaluations.go
@@ -181,7 +181,7 @@ func OSPS_QA_06() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
-			reusable_steps.NotImplemented,
+			documentsTestExecution,
 		},
 	)
 
@@ -192,7 +192,7 @@ func OSPS_QA_06() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
-			reusable_steps.NotImplemented,
+			documentsTestMaintenancePolicy,
 		},
 	)
 

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -314,3 +314,19 @@ func verifyDependencyManifests(payloadData interface{}) (layer4.Result, string) 
 
 	return layer4.Passed, "Dependency management files present and properly configured"
 }
+
+func documentsTestExecution(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+	_, message = reusable_steps.VerifyPayload(payloadData)
+	if message != "" {
+		return layer4.Unknown, message
+	}
+	return layer4.NeedsReview, "Review project documentation to ensure it explains when and how tests are run"
+}
+
+func documentsTestMaintenancePolicy(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+	_, message = reusable_steps.VerifyPayload(payloadData)
+	if message != "" {
+		return layer4.Unknown, message
+	}
+	return layer4.NeedsReview, "Review project documentation to ensure it contains a clear policy for maintaining tests"
+}


### PR DESCRIPTION
This PR provides a simplistic, but arguably valid implementation for both of these controls, which is to explicitly require human review of the project documentation.

The end-user of the evaluation results  will now get more clear guidance on what to review in the control evaluation result message.