### PR TITLE
fix: improve build and lint CI workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,8 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5.4.0
         with:
           go-version: 1.23
-      - name: golangci-lint
+      - name: build
         run: make build
+      - name: test
+        run: make test-cov

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5.4.0
         with:
           go-version: stable


### PR DESCRIPTION
This PR makes the following changes to the workflows:
 * addresses `zizmor` finding https://woodruffw.github.io/zizmor/audits/#artipacked in both actions
 * adds `make test-cover` to the `build` workflow because we should run the tests we have in CI