### PR TITLE
feat: multiple workflows to deal with auto-labelling, auto-releasing

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,69 @@
+---
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+template: |
+  # Changelog
+  $CHANGES
+
+  See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release
+
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "feature"
+      - "enhancement"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"
+  - title: "🧰 Maintenance"
+    labels:
+      - "infrastructure"
+      - "automation"
+      - "documentation"
+      - "dependencies"
+      - "maintenance"
+      - "revert"
+  - title: "🏎 Performance"
+    label: "performance"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+version-resolver:
+  major:
+    labels:
+      - "breaking"
+  minor:
+    labels:
+      - "feature"
+      - "enhancement"
+  patch:
+    labels:
+      - "fix"
+      - "documentation"
+      - "maintenance"
+  default: patch
+autolabeler:
+  - label: "automation"
+    title:
+      - "/^(build|ci|perf|refactor|test).*/i"
+  - label: "enhancement"
+    title:
+      - "/^(style).*/i"
+  - label: "documentation"
+    title:
+      - "/^(docs).*/i"
+  - label: "feature"
+    title:
+      - "/^(feat).*/i"
+  - label: "fix"
+    title:
+      - "/^(fix).*/i"
+  - label: "infrastructure"
+    title:
+      - "/^(infrastructure).*/i"
+  - label: "maintenance"
+    title:
+      - "/^(chore|maintenance).*/i"
+  - label: "revert"
+    title:
+      - "/^(revert).*/i"

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -1,0 +1,18 @@
+---
+name: "Auto Labeler"
+on:
+  # pull_request_target event is required for autolabeler to support all PRs including forks
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+permissions:
+  contents: read
+jobs:
+  auto_labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: github/ospo-reusable-workflows/.github/workflows/auto-labeler.yaml@ecdd405ebb379e0713e348440e6e26e85fc06773
+    with:
+      config-name: release-drafter.yml
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,16 @@
+## Reference: https://github.com/amannn/action-semantic-pull-request
+---
+name: "Lint PR Title"
+on:
+  # pull_request_target event is required for autolabeler to support all PRs including forks
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+jobs:
+  lint_pr_title:
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    uses: github/ospo-reusable-workflows/.github/workflows/pr-title.yaml@ecdd405ebb379e0713e348440e6e26e85fc06773
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+---
+name: "Release"
+on:
+  workflow_dispatch:
+  pull_request_target:
+    types: [closed]
+    branches: [main]
+jobs:
+  release:
+    permissions:
+      contents: write
+      pull-requests: read
+    uses: github/ospo-reusable-workflows/.github/workflows/release.yaml@ecdd405ebb379e0713e348440e6e26e85fc06773
+    with:
+      publish: true
+      release-config-name: release-drafter.yml
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+  goreleaser:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.4
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add workflows for auto-labeling, auto-releasing, pr-title validation

Also add the template for releases and auto-labelling determinations

These have been heavily tested in other repositories:

Examples:

- github.com/privateer/privateer
- github.com/privateer/privateer-sdk

So people don't have to hunt, releasing is handle like so:

If the PR [has been merged and has any of the following labels](https://github.com/github/ospo-reusable-workflows/blob/10cfc2f9be5fce5e90150dfbffc7c0f4e68108ab/.github/workflows/release.yaml#L31-L37):

- breaking
- feature
- vuln
- release (typically manually added)

You can also manually run a release via the GitHub Action UI.

Goreleaser is also involved in the release.