### PR TITLE
feat: implement check for LE-03.02

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ config.yml
 
 .vscode
 output
+
+# go test coverage output
+coverage.out

--- a/evaluation_plans/osps/legal/evaluations.go
+++ b/evaluation_plans/osps/legal/evaluations.go
@@ -88,22 +88,19 @@ func OSPS_LE_03() (evaluation *layer4.ControlEvaluation) {
 		},
 	)
 
-	// Just run the previous assessments for now
 	// TODO: Implement this assessment
-	// evaluation.AddAssessment(
-	// 	"OSPS-LE-03.02",
-	// 	"While active, the license for the released software assets MUST be included in the released source code, or in a LICENSE file, COPYING file, or LICENSE/ directory alongside the corresponding release assets.",
-	// 	[]string{
-	// 		"Maturity Level 1",
-	// 		"Maturity Level 2",
-	// 		"Maturity Level 3",
-	// 	},
-	// 	[]layer4.AssessmentStep{
-	// 		reusable_steps.HasSecurityInsightsFile,
-	// 		reusable_steps.IsActive,
-	// 		reusable_steps.NotImplemented,
-	// 	},
-	// )
+	evaluation.AddAssessment(
+		"OSPS-LE-03.02",
+		"While active, the license for the released software assets MUST be included in the released source code, or in a LICENSE file, COPYING file, or LICENSE/ directory alongside the corresponding release assets.",
+		[]string{
+			"Maturity Level 1",
+			"Maturity Level 2",
+			"Maturity Level 3",
+		},
+		[]layer4.AssessmentStep{
+			releasesLicensed,
+		},
+	)
 
 	return
 }

--- a/evaluation_plans/osps/legal/steps.go
+++ b/evaluation_plans/osps/legal/steps.go
@@ -59,6 +59,21 @@ func foundLicense(payloadData interface{}, _ map[string]*layer4.Change) (result 
 	return layer4.Passed, "License was found in a well known location via the GitHub API"
 }
 
+func releasesLicensed(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+	data, message := reusable_steps.VerifyPayload(payloadData)
+	if message != "" {
+		return layer4.Unknown, message
+	}
+
+	if len(data.Releases) == 0 {
+		return layer4.NotApplicable, "No releases found"
+	}
+	if data.Repository.LicenseInfo.Url == "" {
+		return layer4.Failed, "License was not found in a well known location via the GitHub API"
+	}
+	return layer4.Passed, "GitHub releases include the license(s) in the released source code."
+}
+
 func goodLicense(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {

--- a/evaluation_plans/osps/legal/steps_test.go
+++ b/evaluation_plans/osps/legal/steps_test.go
@@ -1,0 +1,52 @@
+package legal
+
+import (
+	"testing"
+
+	"github.com/revanite-io/pvtr-github-repo/data"
+	"github.com/revanite-io/sci/pkg/layer4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReleasesLicensed(t *testing.T) {
+	tests := []struct {
+		name            string
+		payloadData     interface{}
+		expectedResult  layer4.Result
+		expectedMessage string
+	}{
+		{
+			name: "No releases found",
+			payloadData: data.Payload{
+				RestData: &data.RestData{
+					Releases: []data.ReleaseData{},
+				},
+			},
+			expectedResult:  layer4.NotApplicable,
+			expectedMessage: "No releases found",
+		},
+		{
+			name: "No licenses found",
+			payloadData: data.Payload{
+				RestData: &data.RestData{
+					Releases: []data.ReleaseData{
+						{
+							Name: "v1.0.0",
+						},
+					},
+				},
+				GraphqlRepoData: &data.GraphqlRepoData{},
+			},
+			expectedResult:  layer4.Failed,
+			expectedMessage: "License was not found in a well known location via the GitHub API",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, message := releasesLicensed(test.payloadData, nil)
+			assert.Equal(t, test.expectedResult, result)
+			assert.Equal(t, test.expectedMessage, message)
+		})
+	}
+}


### PR DESCRIPTION
This PR closes https://github.com/revanite-io/pvtr-github-repo/issues/23 by adding logic to check if the project has releases and one or more licenses.

I made the decision to implement the check this way, because of the GitHub docs claim

> GitHub will automatically include links to download a zip file and a tarball containing the contents of the repository at the point of the tag's creation.

in https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases