### PR TITLE
fix: json cannot encode if githubv4.URI is nil

### DIFF
--- a/data/graphql-data.go
+++ b/data/graphql-data.go
@@ -21,9 +21,9 @@ type GraphqlRepoData struct {
 		Object struct {
 			Tree struct {
 				Entries []struct {
-					Name   string
-					Type   string // "blob" for files, "tree" for directories
-					Path   string
+					Name string
+					Type string // "blob" for files, "tree" for directories
+					Path string
 				}
 			} `graphql:"... on Tree"`
 		} `graphql:"object(expression: \"HEAD:\")"`
@@ -87,7 +87,7 @@ type GraphqlRepoData struct {
 		}
 		ContributingGuidelines struct {
 			Body         string
-			ResourcePath githubv4.URI
+			ResourcePath string
 		}
 		DependencyGraphManifests struct {
 			TotalCount int
@@ -96,8 +96,8 @@ type GraphqlRepoData struct {
 				Dependencies struct {
 					TotalCount int
 					Nodes      []struct {
-						PackageName    string
-						Requirements   string
+						PackageName  string
+						Requirements string
 					}
 				} `graphql:"dependencies(first: 100)"`
 			} `graphql:"nodes"`


### PR DESCRIPTION
This resolves an edge case where we fail to export JSON results for a repo that doesn't have a contributing guide. If it isn't found, it returned nil, and that nil couldn't be parsed into json.

Changing the type from `githubv4.URI` to `string` solves the bug.

Resolves #76