### PR TITLE
fix: Removed retrieval of full dependency manifest data

### DIFF
--- a/data/graphql-data.go
+++ b/data/graphql-data.go
@@ -1,14 +1,5 @@
 package data
 
-import (
-	"context"
-	"fmt"
-	"path/filepath"
-
-	"github.com/privateerproj/privateer-sdk/config"
-	"github.com/shurcooL/githubv4"
-)
-
 // GraphqlRepoData is used in a query to get general repository information
 type GraphqlRepoData struct {
 	Repository struct {
@@ -85,22 +76,8 @@ type GraphqlRepoData struct {
 			Description string
 		}
 		ContributingGuidelines struct {
-			Body         string
-			ResourcePath string
+			Body string
 		}
-		DependencyGraphManifests struct {
-			TotalCount int
-			Nodes      []struct {
-				Filename     string
-				Dependencies struct {
-					TotalCount int
-					Nodes      []struct {
-						PackageName  string
-						Requirements string
-					}
-				} `graphql:"dependencies(first: 100)"`
-			} `graphql:"nodes"`
-		} `graphql:"dependencyGraphManifests(first: 100)"`
 		Releases struct {
 			Nodes []struct {
 				TagName string
@@ -114,114 +91,4 @@ type GraphqlRepoData struct {
 			}
 		} `graphql:"releases(first: 1, orderBy: {field: CREATED_AT, direction: DESC})"`
 	} `graphql:"repository(owner: $owner, name: $name)"`
-}
-
-// GraphqlRepoTree is used in a query to get top 3 levels of the repository contents
-type GraphqlRepoTree struct {
-	Repository struct {
-		Object struct {
-			Tree struct {
-				Entries []struct {
-					Name   string
-					Type   string // "blob" for files, "tree" for directories
-					Path   string
-					Object *struct {
-						Tree struct {
-							Entries []struct {
-								Name   string
-								Type   string
-								Path   string
-								Object *struct {
-									Tree struct {
-										Entries []struct {
-											Name string
-											Type string
-											Path string
-										}
-									} `graphql:"... on Tree"`
-								} `graphql:"object"`
-							}
-						} `graphql:"... on Tree"`
-					} `graphql:"object"`
-				}
-			} `graphql:"... on Tree"`
-		} `graphql:"object(expression: $branch)"`
-	} `graphql:"repository(owner: $owner, name: $name)"`
-}
-
-func checkTreeForBinaries(tree *GraphqlRepoTree, binariesFound []string) []string {
-	for _, entry := range tree.Repository.Object.Tree.Entries {
-		binariesFound = identifyBinaries(binariesFound, entry.Type, entry.Name)
-		if entry.Type == "tree" {
-			for _, subEntry := range entry.Object.Tree.Entries {
-				binariesFound = identifyBinaries(binariesFound, subEntry.Type, subEntry.Name)
-				if subEntry.Type == "tree" {
-					for _, subSubEntry := range subEntry.Object.Tree.Entries {
-						binariesFound = identifyBinaries(binariesFound, subSubEntry.Type, subSubEntry.Name)
-						// if subSubEntry.Type == "tree" {
-						// TODO: The current GraphQL call stops after 3 levels of depth.
-						// Additional API calls will be required for recursion if another tree is found.
-						// }
-					}
-				}
-			}
-		}
-	}
-	return binariesFound
-}
-
-func identifyBinaries(binariesFound []string, filetype string, filename string) []string {
-	if filetype == "blob" {
-		if isBinaryFile(filename) {
-			binariesFound = append(binariesFound, filename)
-		}
-	}
-	return binariesFound
-}
-
-// TODO: this is a lightweight check, looking at filenames only.
-// GitHub's GraphQL API has an 'isBinary' field that could be used for a more accurate check,
-// but I didn't manage to get that query working as expected.
-func isBinaryFile(filename string) bool {
-	binaryExtensions := map[string]bool{
-		"": true, ".exe": true, ".dll": true, ".so": true, ".pdf": true,
-		".zip": true, ".tar": true, ".mp4": true, ".mp3": true,
-	}
-	knownFilenames := map[string]bool{
-		// Extend this with more known filenames as needed
-		"README": true, "LICENSE": true, "CHANGELOG": true, "CONTRIBUTING": true,
-		"CODE_OF_CONDUCT": true, "TODO": true, "SECURITY": true, "NOTICE": true, "CODEOWNERS": true,
-		".gitignore": true, ".gitattributes": true, "Makefile": true, "Dockerfile": true,
-		"Vagrantfile": true, "Gemfile": true, "Procfile": true, "Brewfile": true, "MANIFEST": true,
-	}
-	if knownFilenames[filename] {
-		return false
-	}
-	ext := filepath.Ext(filename)
-	return binaryExtensions[ext]
-}
-
-func fetchGraphqlRepoTree(config *config.Config, client *githubv4.Client, branch string) (tree *GraphqlRepoTree, err error) {
-	path := "" // TODO: I suspected we should be able to target subdirectories this way, but it hasn't succeeded
-
-	fullPath := fmt.Sprintf("%s:%s", branch, path) // Ensure correct format
-
-	variables := map[string]interface{}{
-		"owner":  githubv4.String(config.GetString("owner")),
-		"name":   githubv4.String(config.GetString("repo")),
-		"branch": githubv4.String(fullPath),
-	}
-
-	err = client.Query(context.Background(), &tree, variables)
-
-	return tree, err
-}
-
-func getSuspectedBinaries(client *githubv4.Client, config *config.Config, branchName string) (suspectedBinaries []string, err error) {
-	tree, err := fetchGraphqlRepoTree(config, client, branchName)
-	if err != nil {
-		return nil, err
-	}
-	binaryFileNames := checkTreeForBinaries(tree, []string{})
-	return binaryFileNames, nil
 }

--- a/data/graphql-dependency-manifests.go
+++ b/data/graphql-dependency-manifests.go
@@ -1,0 +1,41 @@
+package data
+
+import (
+	"context"
+
+	"github.com/privateerproj/privateer-sdk/config"
+	"github.com/shurcooL/githubv4"
+)
+
+type DependencyManifestsPage struct {
+	Repository struct {
+		DependencyGraphManifests struct {
+			TotalCount int
+		}
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+type ManifestNode struct {
+	Filename     string
+	Dependencies []Dependency
+}
+
+type Dependency struct {
+	PackageName  string
+	Requirements string
+}
+
+func countDependencyManifests(client *githubv4.Client, cfg *config.Config) (int, error) {
+	var query DependencyManifestsPage
+	variables := map[string]interface{}{
+		"owner": githubv4.String(cfg.GetString("owner")),
+		"name":  githubv4.String(cfg.GetString("repo")),
+	}
+
+	err := client.Query(context.Background(), &query, variables)
+	if err != nil {
+		return 0, err
+	}
+
+	return query.Repository.DependencyGraphManifests.TotalCount, nil
+}

--- a/data/graphql-repo-tree.go
+++ b/data/graphql-repo-tree.go
@@ -1,0 +1,120 @@
+package data
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/privateerproj/privateer-sdk/config"
+	"github.com/shurcooL/githubv4"
+)
+
+// GraphqlRepoTree is used in a query to get top 3 levels of the repository contents
+type GraphqlRepoTree struct {
+	Repository struct {
+		Object struct {
+			Tree struct {
+				Entries []struct {
+					Name   string
+					Type   string // "blob" for files, "tree" for directories
+					Path   string
+					Object *struct {
+						Tree struct {
+							Entries []struct {
+								Name   string
+								Type   string
+								Path   string
+								Object *struct {
+									Tree struct {
+										Entries []struct {
+											Name string
+											Type string
+											Path string
+										}
+									} `graphql:"... on Tree"`
+								} `graphql:"object"`
+							}
+						} `graphql:"... on Tree"`
+					} `graphql:"object"`
+				}
+			} `graphql:"... on Tree"`
+		} `graphql:"object(expression: $branch)"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+func checkTreeForBinaries(tree *GraphqlRepoTree, binariesFound []string) []string {
+	for _, entry := range tree.Repository.Object.Tree.Entries {
+		binariesFound = identifyBinaries(binariesFound, entry.Type, entry.Name)
+		if entry.Type == "tree" {
+			for _, subEntry := range entry.Object.Tree.Entries {
+				binariesFound = identifyBinaries(binariesFound, subEntry.Type, subEntry.Name)
+				if subEntry.Type == "tree" {
+					for _, subSubEntry := range subEntry.Object.Tree.Entries {
+						binariesFound = identifyBinaries(binariesFound, subSubEntry.Type, subSubEntry.Name)
+						// if subSubEntry.Type == "tree" {
+						// TODO: The current GraphQL call stops after 3 levels of depth.
+						// Additional API calls will be required for recursion if another tree is found.
+						// }
+					}
+				}
+			}
+		}
+	}
+	return binariesFound
+}
+
+func identifyBinaries(binariesFound []string, filetype string, filename string) []string {
+	if filetype == "blob" {
+		if isBinaryFile(filename) {
+			binariesFound = append(binariesFound, filename)
+		}
+	}
+	return binariesFound
+}
+
+// TODO: this is a lightweight check, looking at filenames only.
+// GitHub's GraphQL API has an 'isBinary' field that could be used for a more accurate check,
+// but I didn't manage to get that query working as expected.
+func isBinaryFile(filename string) bool {
+	binaryExtensions := map[string]bool{
+		"": true, ".exe": true, ".dll": true, ".so": true, ".pdf": true,
+		".zip": true, ".tar": true, ".mp4": true, ".mp3": true,
+	}
+	knownFilenames := map[string]bool{
+		// Extend this with more known filenames as needed
+		"README": true, "LICENSE": true, "CHANGELOG": true, "CONTRIBUTING": true,
+		"CODE_OF_CONDUCT": true, "TODO": true, "SECURITY": true, "NOTICE": true, "CODEOWNERS": true,
+		".gitignore": true, ".gitattributes": true, "Makefile": true, "Dockerfile": true,
+		"Vagrantfile": true, "Gemfile": true, "Procfile": true, "Brewfile": true, "MANIFEST": true,
+	}
+	if knownFilenames[filename] {
+		return false
+	}
+	ext := filepath.Ext(filename)
+	return binaryExtensions[ext]
+}
+
+func fetchGraphqlRepoTree(config *config.Config, client *githubv4.Client, branch string) (tree *GraphqlRepoTree, err error) {
+	path := "" // TODO: I suspected we should be able to target subdirectories this way, but it hasn't succeeded
+
+	fullPath := fmt.Sprintf("%s:%s", branch, path) // Ensure correct format
+
+	variables := map[string]interface{}{
+		"owner":  githubv4.String(config.GetString("owner")),
+		"name":   githubv4.String(config.GetString("repo")),
+		"branch": githubv4.String(fullPath),
+	}
+
+	err = client.Query(context.Background(), &tree, variables)
+
+	return tree, err
+}
+
+func getSuspectedBinaries(client *githubv4.Client, config *config.Config, branchName string) (suspectedBinaries []string, err error) {
+	tree, err := fetchGraphqlRepoTree(config, client, branchName)
+	if err != nil {
+		return nil, err
+	}
+	binaryFileNames := checkTreeForBinaries(tree, []string{})
+	return binaryFileNames, nil
+}

--- a/data/payload.go
+++ b/data/payload.go
@@ -13,9 +13,10 @@ import (
 type Payload struct {
 	*GraphqlRepoData
 	*RestData
-	Config             *config.Config
-	SuspectedBinaries  []string
-	RepositoryMetadata RepositoryMetadata
+	Config                   *config.Config
+	SuspectedBinaries        []string
+	RepositoryMetadata       RepositoryMetadata
+	DependencyManifestsCount int
 }
 
 func Loader(config *config.Config) (payload interface{}, err error) {
@@ -34,17 +35,22 @@ func Loader(config *config.Config) (payload interface{}, err error) {
 	if err != nil {
 		return nil, err
 	}
+	dependencyManifestsCount, err := countDependencyManifests(client, config)
+	if err != nil {
+		return nil, err
+	}
 
 	rest, err := getRestData(ghClient, config)
 	if err != nil {
 		return nil, err
 	}
 	return interface{}(Payload{
-		GraphqlRepoData:    graphql,
-		RestData:           rest,
-		Config:             config,
-		SuspectedBinaries:  suspectedBinaries,
-		RepositoryMetadata: repositoryMetadata,
+		GraphqlRepoData:          graphql,
+		RestData:                 rest,
+		Config:                   config,
+		SuspectedBinaries:        suspectedBinaries,
+		RepositoryMetadata:       repositoryMetadata,
+		DependencyManifestsCount: dependencyManifestsCount,
 	}), nil
 }
 


### PR DESCRIPTION
This change splits up the graphql calls into different files for clarity, and cuts down the dependency manifest call significantly.

The change to the test is debatable... I spent a bunch of time refining the second half of a check that I think won't even be reached. I left a note on that in the function `countDependencyManifests`.

Regardless, this resolves #77 