### PR TITLE
fix: Add error message in the event of error on repo tree query

### DIFF
--- a/data/graphql-binary-check.go
+++ b/data/graphql-binary-check.go
@@ -111,7 +111,7 @@ type GraphqlRepoTree struct {
 	} `graphql:"repository(owner: $owner, name: $name)"`
 }
 
-func checkTreeForBinaries(tree *GraphqlRepoTree, binariesFound []string) []string {
+func checkTreeForBinaries(tree *GraphqlRepoTree) (binariesFound []string) {
 	for _, entry := range tree.Repository.Object.Tree.Entries {
 		binariesFound = identifyBinaries(binariesFound, entry.Type, entry.Name)
 		if entry.Type == "tree" {

--- a/data/graphql-binary-check.go
+++ b/data/graphql-binary-check.go
@@ -9,6 +9,75 @@ import (
 	"github.com/shurcooL/githubv4"
 )
 
+var (
+	binaryExtensions = map[string]bool{
+		"":       true,
+		"tar":    true,
+		"gz":     true,
+		"tgz":    true,
+		"zip":    true,
+		"rar":    true,
+		"7z":     true,
+		"bz2":    true,
+		"xz":     true,
+		"lzma":   true,
+		"lz4":    true,
+		"zst":    true,
+		"apk":    true,
+		"crx":    true,
+		"deb":    true,
+		"dex":    true,
+		"dey":    true,
+		"elf":    true,
+		"o":      true,
+		"a":      true,
+		"so":     true,
+		"macho":  true,
+		"iso":    true,
+		"class":  true,
+		"jar":    true,
+		"bundle": true,
+		"dylib":  true,
+		"lib":    true,
+		"msi":    true,
+		"dll":    true,
+		"drv":    true,
+		"efi":    true,
+		"exe":    true,
+		"ocx":    true,
+		"pyc":    true,
+		"pyo":    true,
+		"par":    true,
+		"rpm":    true,
+		"wasm":   true,
+		"whl":    true,
+	}
+
+	// Extend this with more known filenames as needed
+	knownFilenames = map[string]bool{
+		"README":          true,
+		"LICENSE":         true,
+		"CHANGELOG":       true,
+		"CONTRIBUTING":    true,
+		"CODE_OF_CONDUCT": true,
+		"TODO":            true,
+		"SECURITY":        true,
+		"NOTICE":          true,
+		"CODEOWNERS":      true,
+		".gitignore":      true,
+		".gitattributes":  true,
+		"Makefile":        true,
+		"Dockerfile":      true,
+		"Vagrantfile":     true,
+		"Gemfile":         true,
+		"Procfile":        true,
+		"Brewfile":        true,
+		"MANIFEST":        true,
+		"DCO":             true,
+		"MAINTAINERS":     true,
+	}
+)
+
 // GraphqlRepoTree is used in a query to get top 3 levels of the repository contents
 type GraphqlRepoTree struct {
 	Repository struct {
@@ -76,17 +145,6 @@ func identifyBinaries(binariesFound []string, filetype string, filename string) 
 // GitHub's GraphQL API has an 'isBinary' field that could be used for a more accurate check,
 // but I didn't manage to get that query working as expected.
 func isBinaryFile(filename string) bool {
-	binaryExtensions := map[string]bool{
-		"": true, ".exe": true, ".dll": true, ".so": true, ".pdf": true,
-		".zip": true, ".tar": true, ".mp4": true, ".mp3": true,
-	}
-	knownFilenames := map[string]bool{
-		// Extend this with more known filenames as needed
-		"README": true, "LICENSE": true, "CHANGELOG": true, "CONTRIBUTING": true,
-		"CODE_OF_CONDUCT": true, "TODO": true, "SECURITY": true, "NOTICE": true, "CODEOWNERS": true,
-		".gitignore": true, ".gitattributes": true, "Makefile": true, "Dockerfile": true,
-		"Vagrantfile": true, "Gemfile": true, "Procfile": true, "Brewfile": true, "MANIFEST": true,
-	}
 	if knownFilenames[filename] {
 		return false
 	}
@@ -108,13 +166,4 @@ func fetchGraphqlRepoTree(config *config.Config, client *githubv4.Client, branch
 	err = client.Query(context.Background(), &tree, variables)
 
 	return tree, err
-}
-
-func getSuspectedBinaries(client *githubv4.Client, config *config.Config, branchName string) (suspectedBinaries []string, err error) {
-	tree, err := fetchGraphqlRepoTree(config, client, branchName)
-	if err != nil {
-		return nil, err
-	}
-	binaryFileNames := checkTreeForBinaries(tree, []string{})
-	return binaryFileNames, nil
 }

--- a/data/payload.go
+++ b/data/payload.go
@@ -83,7 +83,7 @@ func getRestData(ghClient *github.Client, config *config.Config) (data *RestData
 }
 
 func (p *Payload) GetSuspectedBinaries() (suspectedBinaries []string, err error) {
-	tree, err := fetchGraphqlRepoTree(p.Config, p.client, p.GraphqlRepoData.Repository.DefaultBranchRef.Name)
+	tree, err := fetchGraphqlRepoTree(p.Config, p.client, p.Repository.DefaultBranchRef.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/data/payload.go
+++ b/data/payload.go
@@ -17,6 +17,8 @@ type Payload struct {
 	SuspectedBinaries        []string
 	RepositoryMetadata       RepositoryMetadata
 	DependencyManifestsCount int
+
+	client *githubv4.Client
 }
 
 func Loader(config *config.Config) (payload interface{}, err error) {
@@ -31,7 +33,6 @@ func Loader(config *config.Config) (payload interface{}, err error) {
 	if err != nil {
 		return nil, err
 	}
-	suspectedBinaries, err := getSuspectedBinaries(client, config, graphql.Repository.DefaultBranchRef.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -48,9 +49,9 @@ func Loader(config *config.Config) (payload interface{}, err error) {
 		GraphqlRepoData:          graphql,
 		RestData:                 rest,
 		Config:                   config,
-		SuspectedBinaries:        suspectedBinaries,
 		RepositoryMetadata:       repositoryMetadata,
 		DependencyManifestsCount: dependencyManifestsCount,
+		client:                   client,
 	}), nil
 }
 
@@ -79,4 +80,13 @@ func getRestData(ghClient *github.Client, config *config.Config) (data *RestData
 		Config:   config,
 	}
 	return r, r.Setup()
+}
+
+func (p *Payload) GetSuspectedBinaries() (suspectedBinaries []string, err error) {
+	tree, err := fetchGraphqlRepoTree(p.Config, p.client, p.GraphqlRepoData.Repository.DefaultBranchRef.Name)
+	if err != nil {
+		return nil, err
+	}
+	binaryFileNames := checkTreeForBinaries(tree, []string{})
+	return binaryFileNames, nil
 }

--- a/data/payload.go
+++ b/data/payload.go
@@ -87,6 +87,6 @@ func (p *Payload) GetSuspectedBinaries() (suspectedBinaries []string, err error)
 	if err != nil {
 		return nil, err
 	}
-	binaryFileNames := checkTreeForBinaries(tree, []string{})
+	binaryFileNames := checkTreeForBinaries(tree)
 	return binaryFileNames, nil
 }

--- a/data/rest-data.go
+++ b/data/rest-data.go
@@ -237,10 +237,6 @@ func (r *RestData) getRepoContents() {
 		return
 	}
 	r.contents.SubContent = make(map[string]RepoContent)
-	if err := r.contents.getSubDirContents(r.ghClient, r.owner, r.repo); err != nil {
-		r.Config.Logger.Error(fmt.Sprintf("failed to retrieve subdirectory contents: %s", err.Error()))
-		return
-	}
 	r.Config.Logger.Trace(fmt.Sprintf("retrieved %d top-level contents and %d subdirectories", len(r.contents.Content), len(r.contents.SubContent)))
 }
 

--- a/data/rest-data.go
+++ b/data/rest-data.go
@@ -240,27 +240,6 @@ func (r *RestData) getRepoContents() {
 	r.Config.Logger.Trace(fmt.Sprintf("retrieved %d top-level contents and %d subdirectories", len(r.contents.Content), len(r.contents.SubContent)))
 }
 
-func (c *RepoContent) getSubDirContents(client *github.Client, owner string, repo string) error {
-	for _, item := range c.Content {
-		if item.GetType() == "dir" {
-			_, content, _, err := client.Repositories.GetContents(context.Background(), owner, repo, item.GetPath(), nil)
-			if err != nil {
-				return fmt.Errorf("error getting subdirectory contents for %s: %s", item.GetPath(), err.Error())
-			}
-			c.SubContent[item.GetName()] = RepoContent{
-				Content:    content,
-				SubContent: make(map[string]RepoContent),
-			}
-		}
-	}
-	for path, subContent := range c.SubContent {
-		if err := subContent.getSubDirContents(client, owner, repo); err != nil {
-			return fmt.Errorf("error getting subdirectory contents for %s: %s", path, err.Error())
-		}
-	}
-	return nil
-}
-
 func (r *RestData) getReleases() error {
 	endpoint := fmt.Sprintf("%s/repos/%s/%s/releases", APIBase, r.owner, r.repo)
 	responseData, err := r.MakeApiCall(endpoint, true)

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -124,18 +124,24 @@ func statusChecksAreRequiredByBranchProtection(payloadData interface{}, _ map[st
 	return layer4.Passed, "No status checks were run that are not required by branch protection"
 }
 
-// TODO: after 3 layers of depth, make additional API calls if a tree is found.
-// TODO: Examine more than just the file name.
 func noBinariesInRepo(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
 	}
 
-	if len(data.SuspectedBinaries) == 0 {
-		return layer4.Passed, "No binaries were found in the repository (Note: this check only examines file names at this time)"
+	// TODO: This only checks the top 3 levels of the repository tree
+	// for common binary file extensions and it fails on very large repositories.
+	suspectedBinaries, err := data.GetSuspectedBinaries()
+	if err != nil {
+		data.Config.Logger.Trace(fmt.Sprintf("unexpected response while checking for binaries: %s", err.Error()))
+		return layer4.Unknown, fmt.Sprintf("Error while scanning repository for binaries, potentially due to repo size. See logs for details.")
 	}
-	return layer4.Failed, fmt.Sprintf("Suspected binaries found in the repository: %s", strings.Join(data.SuspectedBinaries, ", "))
+
+	if len(suspectedBinaries) == 0 {
+		return layer4.Passed, "No common binary file extensions were found in the repository"
+	}
+	return layer4.Failed, fmt.Sprintf("Suspected binaries found in the repository: %s", strings.Join(suspectedBinaries, ", "))
 }
 
 func requiresNonAuthorApproval(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
@@ -145,18 +151,15 @@ func requiresNonAuthorApproval(payloadData interface{}, _ map[string]*layer4.Cha
 	}
 	protection := data.Repository.DefaultBranchRef.BranchProtectionRule
 
-	// Check if reviews are required
 	if !protection.RequiresApprovingReviews {
 		return layer4.Failed, "Branch protection rule does not require reviews"
 	}
 
-	// Check if at least one review is required
 	reviewCount := data.Repository.DefaultBranchRef.RefUpdateRule.RequiredApprovingReviewCount
 	if reviewCount < 1 {
 		return layer4.Failed, "Branch protection rule requires 0 approving reviews"
 	}
 
-	// Check if new commits dismiss previous approvals
 	if !protection.RequireLastPushApproval {
 		return layer4.Failed, "Branch protection does not require re-approval after new commits"
 	}

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -135,7 +135,7 @@ func noBinariesInRepo(payloadData interface{}, _ map[string]*layer4.Change) (res
 	suspectedBinaries, err := data.GetSuspectedBinaries()
 	if err != nil {
 		data.Config.Logger.Trace(fmt.Sprintf("unexpected response while checking for binaries: %s", err.Error()))
-		return layer4.Unknown, fmt.Sprintf("Error while scanning repository for binaries, potentially due to repo size. See logs for details.")
+		return layer4.Unknown, "Error while scanning repository for binaries, potentially due to repo size. See logs for details."
 	}
 
 	if len(suspectedBinaries) == 0 {


### PR DESCRIPTION
This resolves #85 by adding an `Unknown` status for repos that we cannot query the contents of (502 due to repo size).

This resolves #88 by _not_ changing to recursively get every directory, because this proved to be just as problematic by instantly hitting the rate limit threshold when scanning a large repo.