### PR TITLE
fix: MFA will no longer fail if token is unprivileged

### DIFF
--- a/data/repository_metadata.go
+++ b/data/repository_metadata.go
@@ -14,11 +14,10 @@ type RepositoryMetadata interface {
 }
 
 type GitHubRepositoryMetadata struct {
-	Releases                       []ReleaseData
-	Rulesets                       []Ruleset
-	ghRepo                         *github.Repository
-	ghOrg                          *github.Organization
-	unableToEvaluateMFARequirement bool
+	Releases []ReleaseData
+	Rulesets []Ruleset
+	ghRepo   *github.Repository
+	ghOrg    *github.Organization
 }
 
 func (r *GitHubRepositoryMetadata) IsActive() bool {

--- a/data/repository_metadata_test.go
+++ b/data/repository_metadata_test.go
@@ -86,14 +86,15 @@ func TestLoadRepositoryMetadata(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				if testCase.expectedOrgError {
-					assert.True(t, repoMetadata.UnableToEvaluateMFARequirement())
-					assert.False(t, repoMetadata.IsMFARequiredForAdministrativeActions())
+					// When org data can't be retrieved, IsMFARequiredForAdministrativeActions returns nil
+					assert.Nil(t, repoMetadata.IsMFARequiredForAdministrativeActions())
 				} else {
 					assert.NoError(t, err)
 					assert.NotNil(t, repoMetadata)
 					assert.True(t, repoMetadata.IsActive())
 					assert.True(t, repoMetadata.IsPublic())
-					assert.True(t, repoMetadata.IsMFARequiredForAdministrativeActions())
+					assert.NotNil(t, repoMetadata.IsMFARequiredForAdministrativeActions())
+					assert.True(t, *repoMetadata.IsMFARequiredForAdministrativeActions())
 					assert.Nil(t, repoMetadata.OrganizationBlogURL())
 				}
 			}

--- a/evaluation_plans/osps/access_control/steps.go
+++ b/evaluation_plans/osps/access_control/steps.go
@@ -12,9 +12,8 @@ func orgRequiresMFA(payloadData interface{}, _ map[string]*layer4.Change) (resul
 		return layer4.Unknown, message
 	}
 
-	// nullable:o.TwoFactorRequirementEnabled
-
 	required := payload.RepositoryMetadata.IsMFARequiredForAdministrativeActions()
+
 	if required == nil {
 		return layer4.NeedsReview, "Not evaluated. Two-factor authentication evaluation requires a token with org:admin permissions, or manual review"
 	} else if *required {

--- a/evaluation_plans/osps/access_control/steps.go
+++ b/evaluation_plans/osps/access_control/steps.go
@@ -12,11 +12,12 @@ func orgRequiresMFA(payloadData interface{}, _ map[string]*layer4.Change) (resul
 		return layer4.Unknown, message
 	}
 
-	required := payload.RepositoryMetadata.IsMFARequiredForAdministrativeActions()
+	// nullable:o.TwoFactorRequirementEnabled
 
-	if payload.RepositoryMetadata.UnableToEvaluateMFARequirement() {
+	required := payload.RepositoryMetadata.IsMFARequiredForAdministrativeActions()
+	if required == nil {
 		return layer4.NeedsReview, "Not evaluated. Two-factor authentication evaluation requires a token with org:admin permissions, or manual review"
-	} else if required {
+	} else if *required {
 		return layer4.Passed, "Two-factor authentication is configured as required by the parent organization"
 	}
 	return layer4.Failed, "Two-factor authentication is NOT configured as required by the parent organization"

--- a/evaluation_plans/osps/access_control/steps_test.go
+++ b/evaluation_plans/osps/access_control/steps_test.go
@@ -10,26 +10,23 @@ import (
 
 type FakeRepositoryMetadata struct {
 	data.RepositoryMetadata
-	twoFactorEnabled               bool
-	unableToEvaluateMFARequirement bool
+	twoFactorEnabled *bool
 }
 
-func (f *FakeRepositoryMetadata) IsMFARequiredForAdministrativeActions() bool {
+func (f *FakeRepositoryMetadata) IsMFARequiredForAdministrativeActions() *bool {
 	return f.twoFactorEnabled
 }
 
-func (f *FakeRepositoryMetadata) UnableToEvaluateMFARequirement() bool {
-	return f.unableToEvaluateMFARequirement
-}
-
-func stubRepoMetadata(twoFactorEnabled bool, unableToEvaluateMFARequirement bool) *FakeRepositoryMetadata {
+func stubRepoMetadata(twoFactorEnabled *bool) *FakeRepositoryMetadata {
 	return &FakeRepositoryMetadata{
-		twoFactorEnabled:               twoFactorEnabled,
-		unableToEvaluateMFARequirement: unableToEvaluateMFARequirement,
+		twoFactorEnabled: twoFactorEnabled,
 	}
 }
 
 func Test_orgRequiresMFA(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
 	tests := []struct {
 		name        string
 		payload     data.Payload
@@ -39,7 +36,7 @@ func Test_orgRequiresMFA(t *testing.T) {
 		{
 			name: "org requires MFA",
 			payload: data.Payload{
-				RepositoryMetadata: stubRepoMetadata(true, false),
+				RepositoryMetadata: stubRepoMetadata(&trueVal),
 			},
 			wantResult:  layer4.Passed,
 			wantMessage: "Two-factor authentication is configured as required by the parent organization",
@@ -47,7 +44,7 @@ func Test_orgRequiresMFA(t *testing.T) {
 		{
 			name: "org does not require MFA",
 			payload: data.Payload{
-				RepositoryMetadata: stubRepoMetadata(false, false),
+				RepositoryMetadata: stubRepoMetadata(&falseVal),
 			},
 			wantResult:  layer4.Failed,
 			wantMessage: "Two-factor authentication is NOT configured as required by the parent organization",
@@ -55,7 +52,7 @@ func Test_orgRequiresMFA(t *testing.T) {
 		{
 			name: "unable to evaluate MFA requirement",
 			payload: data.Payload{
-				RepositoryMetadata: stubRepoMetadata(false, true),
+				RepositoryMetadata: stubRepoMetadata(nil),
 			},
 			wantResult:  layer4.NeedsReview,
 			wantMessage: "Not evaluated. Two-factor authentication evaluation requires a token with org:admin permissions, or manual review",


### PR DESCRIPTION
This changes to use custom logic instead of `go-githib` to will look for `nil` in the API response to indicate that the token was not authorized to retrieve the MFA data. 