### PR TITLE
refactor: move iscoderepo to reusable steps

### DIFF
--- a/data/graphql-binary-check.go
+++ b/data/graphql-binary-check.go
@@ -157,7 +157,7 @@ func fetchGraphqlRepoTree(config *config.Config, client *githubv4.Client, branch
 
 	fullPath := fmt.Sprintf("%s:%s", branch, path) // Ensure correct format
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":  githubv4.String(config.GetString("owner")),
 		"name":   githubv4.String(config.GetString("repo")),
 		"branch": githubv4.String(fullPath),

--- a/data/graphql-dependency-manifests.go
+++ b/data/graphql-dependency-manifests.go
@@ -27,7 +27,7 @@ type Dependency struct {
 
 func countDependencyManifests(client *githubv4.Client, cfg *config.Config) (int, error) {
 	var query DependencyManifestsPage
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner": githubv4.String(cfg.GetString("owner")),
 		"name":  githubv4.String(cfg.GetString("repo")),
 	}

--- a/data/payload.go
+++ b/data/payload.go
@@ -22,8 +22,8 @@ type Payload struct {
 	client *githubv4.Client
 }
 
-func Loader(config *config.Config) (payload interface{}, err error) {
-	graphql, client, err := getGraphqlRepoData(config)
+func Loader(config *config.Config) (payload any, err error) {
+	graphql, client, err := getGraphqlRepoData(config) // API Call for GraphqlRepoData, gets general info for repos
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +52,7 @@ func Loader(config *config.Config) (payload interface{}, err error) {
 		return nil, err
 	}
 
-	return interface{}(Payload{
+	return any(Payload{
 		GraphqlRepoData:          graphql,
 		RestData:                 rest,
 		Config:                   config,
@@ -70,7 +70,7 @@ func getGraphqlRepoData(config *config.Config) (data *GraphqlRepoData, client *g
 	httpClient := oauth2.NewClient(context.Background(), src)
 	client = githubv4.NewClient(httpClient)
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner": githubv4.String(config.GetString("owner")),
 		"name":  githubv4.String(config.GetString("repo")),
 	}

--- a/data/rest-data.go
+++ b/data/rest-data.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
 	"net/http"
 	"strings"
 

--- a/evaluation_plans/osps/access_control/evaluations.go
+++ b/evaluation_plans/osps/access_control/evaluations.go
@@ -67,6 +67,7 @@ func OSPS_AC_03() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			branchProtectionRestrictsPushes, // This checks branch protection, but not rulesets yet
 		},
 	)

--- a/evaluation_plans/osps/access_control/steps.go
+++ b/evaluation_plans/osps/access_control/steps.go
@@ -27,9 +27,7 @@ func branchProtectionRestrictsPushes(payloadData interface{}, _ map[string]*laye
 	if message != "" {
 		return layer4.Unknown, message
 	}
-	if !payload.IsCodeRepo {
-		return layer4.NotApplicable, "Repository contains no code - skipping branch protection checks"
-	}
+	
 	protectionData := payload.Repository.DefaultBranchRef.BranchProtectionRule
 
 	if protectionData.RestrictsPushes {

--- a/evaluation_plans/osps/access_control/steps.go
+++ b/evaluation_plans/osps/access_control/steps.go
@@ -6,7 +6,7 @@ import (
 	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/reusable_steps"
 )
 
-func orgRequiresMFA(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func orgRequiresMFA(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	payload, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -22,7 +22,7 @@ func orgRequiresMFA(payloadData interface{}, _ map[string]*layer4.Change) (resul
 	return layer4.Failed, "Two-factor authentication is NOT configured as required by the parent organization"
 }
 
-func branchProtectionRestrictsPushes(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func branchProtectionRestrictsPushes(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	payload, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -43,7 +43,7 @@ func branchProtectionRestrictsPushes(payloadData interface{}, _ map[string]*laye
 	return
 }
 
-func branchProtectionPreventsDeletion(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func branchProtectionPreventsDeletion(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	payload, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -61,7 +61,7 @@ func branchProtectionPreventsDeletion(payloadData interface{}, _ map[string]*lay
 	return
 }
 
-func workflowDefaultReadPermissions(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func workflowDefaultReadPermissions(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	payload, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message

--- a/evaluation_plans/osps/build_release/evaluations.go
+++ b/evaluation_plans/osps/build_release/evaluations.go
@@ -23,6 +23,7 @@ func OSPS_BR_01() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			cicdSanitizedInputParameters,
 		},
 	)

--- a/evaluation_plans/osps/build_release/steps.go
+++ b/evaluation_plans/osps/build_release/steps.go
@@ -40,9 +40,7 @@ func cicdSanitizedInputParameters(payloadData interface{}, _ map[string]*layer4.
 	if message != "" {
 		return layer4.Unknown, message
 	}
-	if !data.IsCodeRepo {
-		return layer4.NotApplicable, "Repository contains no code - skipping CI/CD checks"
-	}
+	
 
 	workflows, err := data.GetDirectoryContent(".github/workflows")
 	if len(workflows) == 0 {

--- a/evaluation_plans/osps/build_release/steps.go
+++ b/evaluation_plans/osps/build_release/steps.go
@@ -33,7 +33,7 @@ var untrustedVarsRegex = `.*(github\.event\.issue\.title|` +
 	`github\.event\.pull_request\.head\.repo\.default_branch|` +
 	`github\.head_ref).*`
 
-func cicdSanitizedInputParameters(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func cicdSanitizedInputParameters(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 
 	// parse the payload and see if we pass our checks
 	data, message := reusable_steps.VerifyPayload(payloadData)
@@ -156,7 +156,7 @@ func pullVariablesFromScript(script string) []string {
 
 }
 
-func releaseHasUniqueIdentifier(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func releaseHasUniqueIdentifier(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -234,7 +234,7 @@ func insecureURI(uri string) bool {
 	return true
 }
 
-func ensureInsightsLinksUseHTTPS(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func ensureInsightsLinksUseHTTPS(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -253,7 +253,7 @@ func ensureInsightsLinksUseHTTPS(payloadData interface{}, _ map[string]*layer4.C
 	return layer4.Passed, "All links use HTTPS"
 }
 
-func ensureLatestReleaseHasChangelog(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func ensureLatestReleaseHasChangelog(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -266,7 +266,7 @@ func ensureLatestReleaseHasChangelog(payloadData interface{}, _ map[string]*laye
 	return layer4.Failed, "The latest release does not have mention of a changelog: \n" + releaseDescription
 }
 
-func insightsHasSlsaAttestation(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func insightsHasSlsaAttestation(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -282,7 +282,7 @@ func insightsHasSlsaAttestation(payloadData interface{}, _ map[string]*layer4.Ch
 	return layer4.Failed, "No SLSA attestation found in security insights"
 }
 
-func distributionPointsUseHTTPS(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func distributionPointsUseHTTPS(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message

--- a/evaluation_plans/osps/docs/evaluations.go
+++ b/evaluation_plans/osps/docs/evaluations.go
@@ -145,6 +145,7 @@ func OSPS_DO_06() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			reusable_steps.HasMadeReleases,
 			reusable_steps.HasSecurityInsightsFile,
 			hasDependencyManagementPolicy,

--- a/evaluation_plans/osps/docs/steps.go
+++ b/evaluation_plans/osps/docs/steps.go
@@ -6,7 +6,7 @@ import (
 	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/reusable_steps"
 )
 
-func hasSupportDocs(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func hasSupportDocs(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -20,7 +20,7 @@ func hasSupportDocs(payloadData interface{}, _ map[string]*layer4.Change) (resul
 	return layer4.Failed, "A support.md file or support statements in the readme.md was NOT found"
 }
 
-func hasUserGuides(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func hasUserGuides(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -33,7 +33,7 @@ func hasUserGuides(payloadData interface{}, _ map[string]*layer4.Change) (result
 	return layer4.Passed, "User guide was specified in Security Insights data"
 }
 
-func acceptsVulnReports(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func acceptsVulnReports(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -46,7 +46,7 @@ func acceptsVulnReports(payloadData interface{}, _ map[string]*layer4.Change) (r
 	return layer4.Failed, "Repository does not accept vulnerability reports"
 }
 
-func hasSignatureVerificationGuide(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func hasSignatureVerificationGuide(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -59,7 +59,7 @@ func hasSignatureVerificationGuide(payloadData interface{}, _ map[string]*layer4
 	return layer4.Passed, "Signature verification guide was specified in Security Insights data"
 }
 
-func hasDependencyManagementPolicy(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func hasDependencyManagementPolicy(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message

--- a/evaluation_plans/osps/governance/evaluations.go
+++ b/evaluation_plans/osps/governance/evaluations.go
@@ -81,6 +81,7 @@ func OSPS_GV_03() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			hasContributionGuide,
 		},
 	)

--- a/evaluation_plans/osps/governance/steps.go
+++ b/evaluation_plans/osps/governance/steps.go
@@ -5,7 +5,7 @@ import (
 	"github.com/revanite-io/sci/pkg/layer4"
 )
 
-func coreTeamIsListed(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func coreTeamIsListed(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -18,7 +18,7 @@ func coreTeamIsListed(payloadData interface{}, _ map[string]*layer4.Change) (res
 	return layer4.Passed, "Core team was specified in Security Insights data"
 }
 
-func projectAdminsListed(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func projectAdminsListed(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -31,7 +31,7 @@ func projectAdminsListed(payloadData interface{}, _ map[string]*layer4.Change) (
 	return layer4.Passed, "Project admins were specified in Security Insights data"
 }
 
-func hasRolesAndResponsibilities(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func hasRolesAndResponsibilities(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -44,7 +44,7 @@ func hasRolesAndResponsibilities(payloadData interface{}, _ map[string]*layer4.C
 	return layer4.Passed, "Roles and responsibilities were specified in Security Insights data"
 }
 
-func hasContributionGuide(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func hasContributionGuide(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -65,7 +65,7 @@ func hasContributionGuide(payloadData interface{}, _ map[string]*layer4.Change) 
 	return layer4.Failed, "Contribution guide not found in Security Insights data or via GitHub API"
 }
 
-func hasContributionReviewPolicy(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func hasContributionReviewPolicy(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message

--- a/evaluation_plans/osps/governance/steps.go
+++ b/evaluation_plans/osps/governance/steps.go
@@ -70,9 +70,6 @@ func hasContributionReviewPolicy(payloadData interface{}, _ map[string]*layer4.C
 	if message != "" {
 		return layer4.Unknown, message
 	}
-	if !data.IsCodeRepo {
-		return layer4.NotApplicable, "Repository contains no code - skipping code contribution policy check"
-	}
 	if data.Insights.Repository.Documentation.ReviewPolicy != "" {
 		return layer4.Passed, "Code review guide was specified in Security Insights data"
 	}

--- a/evaluation_plans/osps/legal/steps.go
+++ b/evaluation_plans/osps/legal/steps.go
@@ -48,7 +48,7 @@ func splitSpdxExpression(expression string) (spdx_ids []string) {
 	return
 }
 
-func foundLicense(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func foundLicense(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -59,7 +59,7 @@ func foundLicense(payloadData interface{}, _ map[string]*layer4.Change) (result 
 	return layer4.Passed, "License was found in a well known location via the GitHub API"
 }
 
-func releasesLicensed(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func releasesLicensed(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -74,7 +74,7 @@ func releasesLicensed(payloadData interface{}, _ map[string]*layer4.Change) (res
 	return layer4.Passed, "GitHub releases include the license(s) in the released source code."
 }
 
-func goodLicense(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func goodLicense(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message

--- a/evaluation_plans/osps/legal/steps_test.go
+++ b/evaluation_plans/osps/legal/steps_test.go
@@ -11,7 +11,7 @@ import (
 func TestReleasesLicensed(t *testing.T) {
 	tests := []struct {
 		name            string
-		payloadData     interface{}
+		payloadData     any
 		expectedResult  layer4.Result
 		expectedMessage string
 	}{

--- a/evaluation_plans/osps/quality/evaluations.go
+++ b/evaluation_plans/osps/quality/evaluations.go
@@ -113,6 +113,7 @@ func OSPS_QA_04() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			reusable_steps.HasSecurityInsightsFile,
 			reusable_steps.IsActive,
 			insightsListsRepositories,
@@ -172,6 +173,7 @@ func OSPS_QA_06() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			hasOneOrMoreStatusChecks,
 		},
 	)
@@ -183,6 +185,7 @@ func OSPS_QA_06() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			documentsTestExecution,
 		},
 	)
@@ -194,6 +197,7 @@ func OSPS_QA_06() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			documentsTestMaintenancePolicy,
 		},
 	)

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -8,7 +8,7 @@ import (
 	"github.com/revanite-io/sci/pkg/layer4"
 )
 
-func repoIsPublic(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func repoIsPublic(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -19,7 +19,7 @@ func repoIsPublic(payloadData interface{}, _ map[string]*layer4.Change) (result 
 	return layer4.Failed, "Repository is private"
 }
 
-func insightsListsRepositories(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func insightsListsRepositories(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -32,7 +32,7 @@ func insightsListsRepositories(payloadData interface{}, _ map[string]*layer4.Cha
 	return layer4.Failed, "Insights does NOT contains a list of repositories"
 }
 
-func statusChecksAreRequiredByRulesets(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func statusChecksAreRequiredByRulesets(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -84,7 +84,7 @@ func statusChecksAreRequiredByRulesets(payloadData interface{}, _ map[string]*la
 	return layer4.Passed, "No status checks were run that are not required by the rules"
 }
 
-func statusChecksAreRequiredByBranchProtection(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func statusChecksAreRequiredByBranchProtection(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -124,7 +124,7 @@ func statusChecksAreRequiredByBranchProtection(payloadData interface{}, _ map[st
 	return layer4.Passed, "No status checks were run that are not required by branch protection"
 }
 
-func noBinariesInRepo(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func noBinariesInRepo(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -144,7 +144,7 @@ func noBinariesInRepo(payloadData interface{}, _ map[string]*layer4.Change) (res
 	return layer4.Failed, fmt.Sprintf("Suspected binaries found in the repository: %s", strings.Join(suspectedBinaries, ", "))
 }
 
-func requiresNonAuthorApproval(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func requiresNonAuthorApproval(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -167,7 +167,7 @@ func requiresNonAuthorApproval(payloadData interface{}, _ map[string]*layer4.Cha
 	return layer4.Passed, fmt.Sprintf("Branch protection requires %d approving reviews and re-approval after new commits", reviewCount)
 }
 
-func hasOneOrMoreStatusChecks(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func hasOneOrMoreStatusChecks(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -190,7 +190,7 @@ func hasOneOrMoreStatusChecks(payloadData interface{}, _ map[string]*layer4.Chan
 	return layer4.Failed, "No status checks were run"
 }
 
-func verifyDependencyManagement(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func verifyDependencyManagement(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -206,7 +206,7 @@ func verifyDependencyManagement(payloadData interface{}, _ map[string]*layer4.Ch
 	return countDependencyManifests(data)
 }
 
-func countDependencyManifests(payloadData interface{}) (result layer4.Result, message string) {
+func countDependencyManifests(payloadData any) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -219,7 +219,7 @@ func countDependencyManifests(payloadData interface{}) (result layer4.Result, me
 	return layer4.Failed, "No dependency manifests found in the repository by the GitHub API"
 }
 
-func documentsTestExecution(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func documentsTestExecution(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	_, message = reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -228,7 +228,7 @@ func documentsTestExecution(payloadData interface{}, _ map[string]*layer4.Change
 	return layer4.NeedsReview, "Review project documentation to ensure it explains when and how tests are run"
 }
 
-func documentsTestMaintenancePolicy(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func documentsTestMaintenancePolicy(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	_, message = reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -24,9 +24,7 @@ func insightsListsRepositories(payloadData interface{}, _ map[string]*layer4.Cha
 	if message != "" {
 		return layer4.Unknown, message
 	}
-	if !data.IsCodeRepo {
-		return layer4.NotApplicable, "Repository contains no code - skipping QA checks"
-	}
+
 	if len(data.Insights.Project.Repositories) > 0 {
 		return layer4.Passed, "Insights contains a list of repositories"
 	}
@@ -174,9 +172,6 @@ func hasOneOrMoreStatusChecks(payloadData interface{}, _ map[string]*layer4.Chan
 	if message != "" {
 		return layer4.Unknown, message
 	}
-	if !data.IsCodeRepo {
-		return layer4.NotApplicable, "Repository contains no code - skipping QA checks"
-	}
 
 	// get the name of all status checks that were run
 	var statusChecks []string
@@ -199,9 +194,6 @@ func verifyDependencyManagement(payloadData interface{}, _ map[string]*layer4.Ch
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
-	}
-	if !data.IsCodeRepo {
-		return layer4.NotApplicable, "Repository contains no code - skipping QA checks"
 	}
 	// Validate required fields
 	if data.Repository.Name == "" || data.Repository.DefaultBranchRef.Name == "" ||

--- a/evaluation_plans/osps/vuln_management/evaluations.go
+++ b/evaluation_plans/osps/vuln_management/evaluations.go
@@ -42,6 +42,7 @@ func OSPS_VM_02() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 1",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			hasSecContact,
 		},
 	)
@@ -168,6 +169,7 @@ func OSPS_VM_06() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			reusable_steps.HasSecurityInsightsFile,
 			sastToolDefined,
 		},

--- a/evaluation_plans/osps/vuln_management/steps.go
+++ b/evaluation_plans/osps/vuln_management/steps.go
@@ -13,9 +13,6 @@ func hasSecContact(payloadData interface{}, _ map[string]*layer4.Change) (result
 	if message != "" {
 		return layer4.Unknown, message
 	}
-	if !data.IsCodeRepo {
-		return layer4.NotApplicable, "Repository contains no code - skipping vulnerability management checks"
-	}
 
 	// TODO: Check for a contact email in SECURITY.md
 

--- a/evaluation_plans/osps/vuln_management/steps.go
+++ b/evaluation_plans/osps/vuln_management/steps.go
@@ -8,7 +8,7 @@ import (
 	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/reusable_steps"
 )
 
-func hasSecContact(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func hasSecContact(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -28,7 +28,7 @@ func hasSecContact(payloadData interface{}, _ map[string]*layer4.Change) (result
 	return layer4.Failed, "Security contacts were not specified in Security Insights data"
 }
 
-func sastToolDefined(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func sastToolDefined(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message

--- a/evaluation_plans/osps/vuln_management/steps_test.go
+++ b/evaluation_plans/osps/vuln_management/steps_test.go
@@ -10,22 +10,21 @@ import (
 )
 
 type testingData struct {
-	expectedResult layer4.Result
-	expectedMessage string
-	payloadData interface{}
+	expectedResult   layer4.Result
+	expectedMessage  string
+	payloadData      any
 	assertionMessage string
 }
 
-
 func TestSastToolDefined(t *testing.T) {
-	
+
 	testData := []testingData{
 		{
-			expectedResult: layer4.Passed,
-			expectedMessage: "Static Application Security Testing documented in Security Insights",
+			expectedResult:   layer4.Passed,
+			expectedMessage:  "Static Application Security Testing documented in Security Insights",
 			assertionMessage: "Test for SAST integration enabled",
-			payloadData:    data.Payload{
-				RestData: &data.RestData {
+			payloadData: data.Payload{
+				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Repository: si.Repository{
 							Security: si.SecurityInfo{
@@ -42,14 +41,13 @@ func TestSastToolDefined(t *testing.T) {
 					},
 				},
 			},
-			
 		},
 		{
-			expectedResult: layer4.Failed,
-			expectedMessage: "No Static Application Security Testing documented in Security Insights",
+			expectedResult:   layer4.Failed,
+			expectedMessage:  "No Static Application Security Testing documented in Security Insights",
 			assertionMessage: "Test for SAST integration present but not explicitly enabled",
-			payloadData:    data.Payload{
-				RestData: &data.RestData {
+			payloadData: data.Payload{
+				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Repository: si.Repository{
 							Security: si.SecurityInfo{
@@ -63,14 +61,13 @@ func TestSastToolDefined(t *testing.T) {
 					},
 				},
 			},
-			
 		},
 		{
-			expectedResult: layer4.Failed,
-			expectedMessage: "No Static Application Security Testing documented in Security Insights",
+			expectedResult:   layer4.Failed,
+			expectedMessage:  "No Static Application Security Testing documented in Security Insights",
 			assertionMessage: "Test for Non SAST tool defined",
-			payloadData:    data.Payload{
-				RestData: &data.RestData {
+			payloadData: data.Payload{
+				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Repository: si.Repository{
 							Security: si.SecurityInfo{
@@ -84,31 +81,28 @@ func TestSastToolDefined(t *testing.T) {
 					},
 				},
 			},
-			
 		},
 		{
-			expectedResult: layer4.Failed,
-			expectedMessage: "No Static Application Security Testing documented in Security Insights",
+			expectedResult:   layer4.Failed,
+			expectedMessage:  "No Static Application Security Testing documented in Security Insights",
 			assertionMessage: "Test for no tools defined",
-			payloadData:    data.Payload{
-				RestData: &data.RestData {
+			payloadData: data.Payload{
+				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Repository: si.Repository{
-							Security: si.SecurityInfo{
-							},
+							Security: si.SecurityInfo{},
 						},
 					},
 				},
 			},
-			
 		},
 	}
-	
+
 	for _, test := range testData {
 		result, message := sastToolDefined(test.payloadData, nil)
 
 		assert.Equal(t, test.expectedResult, result, test.assertionMessage)
 		assert.Equal(t, test.expectedMessage, message, test.assertionMessage)
 	}
-	
+
 }

--- a/evaluation_plans/reusable_steps/evaluations.go
+++ b/evaluation_plans/reusable_steps/evaluations.go
@@ -8,7 +8,7 @@ import (
 	"github.com/revanite-io/pvtr-github-repo/data"
 )
 
-func VerifyPayload(payloadData interface{}) (payload data.Payload, message string) {
+func VerifyPayload(payloadData any) (payload data.Payload, message string) {
 	payload, ok := payloadData.(data.Payload)
 	if !ok {
 		message = fmt.Sprintf("Malformed assessment: expected payload type %T, got %T (%v)", data.Payload{}, payloadData, payloadData)
@@ -16,11 +16,11 @@ func VerifyPayload(payloadData interface{}) (payload data.Payload, message strin
 	return
 }
 
-func NotImplemented(payloadData interface{}, changes map[string]*layer4.Change) (result layer4.Result, message string) {
+func NotImplemented(payloadData any, changes map[string]*layer4.Change) (result layer4.Result, message string) {
 	return layer4.NeedsReview, "Not implemented"
 }
 
-func GithubBuiltIn(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func GithubBuiltIn(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	_, message = VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -29,11 +29,11 @@ func GithubBuiltIn(payloadData interface{}, _ map[string]*layer4.Change) (result
 	return layer4.Passed, "This control is enforced by GitHub for all projects"
 }
 
-func GithubTermsOfService(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func GithubTermsOfService(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	return layer4.Passed, "This control is satisfied by the GitHub Terms of Service"
 }
 
-func HasSecurityInsightsFile(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func HasSecurityInsightsFile(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	payload, message := VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -46,7 +46,7 @@ func HasSecurityInsightsFile(payloadData interface{}, _ map[string]*layer4.Chang
 	return layer4.Passed, "Security insights file found"
 }
 
-func HasMadeReleases(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func HasMadeReleases(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	payload, message := VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -59,7 +59,7 @@ func HasMadeReleases(payloadData interface{}, _ map[string]*layer4.Change) (resu
 	return layer4.Passed, fmt.Sprintf("Found %v releases", len(payload.Releases))
 }
 
-func IsActive(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func IsActive(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	payload, message := VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -74,7 +74,7 @@ func IsActive(payloadData interface{}, _ map[string]*layer4.Change) (result laye
 	return result, fmt.Sprintf("Repo Status is %s", payload.Insights.Repository.Status)
 }
 
-func HasIssuesOrDiscussionsEnabled(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func HasIssuesOrDiscussionsEnabled(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	data, message := VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -92,7 +92,7 @@ func HasIssuesOrDiscussionsEnabled(payloadData interface{}, _ map[string]*layer4
 	return layer4.Failed, "Both issues and discussions are disabled for the repository"
 }
 
-func HasDependencyManagementPolicy(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func HasDependencyManagementPolicy(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	payload, message := VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message
@@ -105,7 +105,7 @@ func HasDependencyManagementPolicy(payloadData interface{}, _ map[string]*layer4
 	return layer4.Failed, "No dependency management file found"
 }
 
-func IsCodeRepo(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+func IsCodeRepo(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
 	payload, message := VerifyPayload(payloadData)
 	if message != "" {
 		return layer4.Unknown, message

--- a/evaluation_plans/reusable_steps/evaluations.go
+++ b/evaluation_plans/reusable_steps/evaluations.go
@@ -104,3 +104,17 @@ func HasDependencyManagementPolicy(payloadData interface{}, _ map[string]*layer4
 
 	return layer4.Failed, "No dependency management file found"
 }
+
+func IsCodeRepo(payloadData interface{}, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+	payload, message := VerifyPayload(payloadData)
+	if message != "" {
+		return layer4.Unknown, message
+	}
+
+	if !payload.IsCodeRepo {
+		return layer4.NotApplicable, "Repository does not contain code"
+	}
+
+	return layer4.Passed, "Repository contains code"
+}
+

--- a/evaluation_plans/reusable_steps/evaluations_test.go
+++ b/evaluation_plans/reusable_steps/evaluations_test.go
@@ -12,7 +12,7 @@ import (
 type testingData struct {
 	expectedResult   layer4.Result
 	expectedMessage  string
-	payloadData      interface{}
+	payloadData      any
 	assertionMessage string
 }
 


### PR DESCRIPTION
Refactors IsCodeRepo functionality into reusable steps and modernizes codebase by replacing `interface{}` with `any`.

## Changes
- **Moved IsCodeRepo to reusable steps**: Centralized in `evaluation_plans/reusable_steps/evaluations.go`
- **Added IsCodeRepo field to Payload struct**: Tracks repository type
- **Integrated IsCodeRepo checks**: Added to evaluation steps across OSPS categories
- **Modernized types**: Replaced `interface{}` with `any` throughout codebase
- **Added IsCodeRepo() method**: Checks GitHub API for repository languages

## Merge Conflicts Resolved
- Resolved conflicts from upstream changes while working on feature branch
- Integrated new upstream features with existing IsCodeRepo functionality