### PR TITLE
refactor: Move IsCodeRepo checks to reusable steps

### DIFF
--- a/evaluation_plans/osps/access_control/evaluations.go
+++ b/evaluation_plans/osps/access_control/evaluations.go
@@ -67,6 +67,7 @@ func OSPS_AC_03() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			branchProtectionRestrictsPushes, // This checks branch protection, but not rulesets yet
 		},
 	)

--- a/evaluation_plans/osps/build_release/evaluations.go
+++ b/evaluation_plans/osps/build_release/evaluations.go
@@ -23,6 +23,7 @@ func OSPS_BR_01() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			cicdSanitizedInputParameters,
 		},
 	)

--- a/evaluation_plans/osps/docs/evaluations.go
+++ b/evaluation_plans/osps/docs/evaluations.go
@@ -145,6 +145,7 @@ func OSPS_DO_06() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			reusable_steps.HasMadeReleases,
 			reusable_steps.HasSecurityInsightsFile,
 			hasDependencyManagementPolicy,

--- a/evaluation_plans/osps/governance/evaluations.go
+++ b/evaluation_plans/osps/governance/evaluations.go
@@ -93,6 +93,7 @@ func OSPS_GV_03() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			reusable_steps.HasSecurityInsightsFile,
 			reusable_steps.IsActive,
 			hasContributionReviewPolicy,

--- a/evaluation_plans/osps/quality/evaluations.go
+++ b/evaluation_plans/osps/quality/evaluations.go
@@ -113,6 +113,7 @@ func OSPS_QA_04() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			reusable_steps.HasSecurityInsightsFile,
 			reusable_steps.IsActive,
 			insightsListsRepositories,
@@ -172,6 +173,7 @@ func OSPS_QA_06() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			hasOneOrMoreStatusChecks,
 		},
 	)
@@ -194,6 +196,7 @@ func OSPS_QA_06() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			documentsTestMaintenancePolicy,
 		},
 	)

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -24,9 +24,7 @@ func insightsListsRepositories(payloadData any, _ map[string]*layer4.Change) (re
 	if message != "" {
 		return layer4.Unknown, message
 	}
-	if !data.IsCodeRepo {
-		return layer4.NotApplicable, "Repository contains no code - skipping QA checks"
-	}
+	
 	if len(data.Insights.Project.Repositories) > 0 {
 		return layer4.Passed, "Insights contains a list of repositories"
 	}
@@ -174,9 +172,6 @@ func hasOneOrMoreStatusChecks(payloadData any, _ map[string]*layer4.Change) (res
 	if message != "" {
 		return layer4.Unknown, message
 	}
-	if !data.IsCodeRepo {
-		return layer4.NotApplicable, "Repository contains no code - skipping QA checks"
-	}
 
 	// get the name of all status checks that were run
 	var statusChecks []string
@@ -200,9 +195,7 @@ func verifyDependencyManagement(payloadData any, _ map[string]*layer4.Change) (r
 	if message != "" {
 		return layer4.Unknown, message
 	}
-	if !data.IsCodeRepo {
-		return layer4.NotApplicable, "Repository contains no code - skipping QA checks"
-	}
+	
 	// Validate required fields
 	if data.Repository.Name == "" || data.Repository.DefaultBranchRef.Name == "" ||
 		data.Repository.DefaultBranchRef.Target.OID == "" {

--- a/evaluation_plans/osps/vuln_management/evaluations.go
+++ b/evaluation_plans/osps/vuln_management/evaluations.go
@@ -42,6 +42,7 @@ func OSPS_VM_02() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 1",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			hasSecContact,
 		},
 	)
@@ -168,6 +169,7 @@ func OSPS_VM_06() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
+			reusable_steps.IsCodeRepo,
 			reusable_steps.HasSecurityInsightsFile,
 			sastToolDefined,
 		},

--- a/evaluation_plans/osps/vuln_management/steps.go
+++ b/evaluation_plans/osps/vuln_management/steps.go
@@ -13,9 +13,7 @@ func hasSecContact(payloadData any, _ map[string]*layer4.Change) (result layer4.
 	if message != "" {
 		return layer4.Unknown, message
 	}
-	if !data.IsCodeRepo {
-		return layer4.NotApplicable, "Repository contains no code - skipping vulnerability management checks"
-	}
+	
 
 	// TODO: Check for a contact email in SECURITY.md
 

--- a/evaluation_plans/reusable_steps/evaluations.go
+++ b/evaluation_plans/reusable_steps/evaluations.go
@@ -104,3 +104,16 @@ func HasDependencyManagementPolicy(payloadData any, _ map[string]*layer4.Change)
 
 	return layer4.Failed, "No dependency management file found"
 }
+
+func IsCodeRepo(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+	payload, message := VerifyPayload(payloadData)
+	if message != "" {
+		return layer4.Unknown, message
+	}
+
+	if !payload.IsCodeRepo {
+		return layer4.NotApplicable, "Repository does not contain code"
+	}
+
+	return layer4.Passed, "Repository contains code"
+}


### PR DESCRIPTION
 Summary
Refactors IsCodeRepo functionality into reusable steps for better code organization and maintainability.

Changes
- Added IsCodeRepo() to reusable_steps**: Centralized IsCodeRepo checks in `evaluation_plans/reusable_steps/evaluations.go`
- Updated evaluation steps**: Replaced individual IsCodeRepo checks with reusable function calls


