### PR TITLE
fix: binary known files validation

### DIFF
--- a/data/graphql-binary-check.go
+++ b/data/graphql-binary-check.go
@@ -75,6 +75,7 @@ var (
 		"MANIFEST":        true,
 		"DCO":             true,
 		"MAINTAINERS":     true,
+		"CNAME":           true,
 	}
 )
 


### PR DESCRIPTION
## Description
This PR addresses an issue where the PVTR GitHub repo plugin incorrectly flags CNAME files as "suspected binaries", causing the OSPS-QA-05 control check to fail.

## Background
Control ID: OSPS-QA-05
Requirement: OSPS-QA-05.01 – "While active, the version control system MUST NOT contain generated executable artifacts."
Current Behavior: CNAME files are incorrectly flagged as binary artifacts.
Expected Behavior: CNAME files, which are legitimate DNS configuration files, should not be flagged as binaries.

## Changes Introduced
* Added CNAME to the binary detection allowlist.

## Reason for Change
This prevents legitimate DNS configuration files from being misclassified as generated binary artifacts, reducing false positives in QA checks.

#### Example Affected Repository
* [hiero-ledger/sdk-collaboration-hub](https://github.com/hiero-ledger/sdk-collaboration-hub)
 — The CNAME file in this repo was incorrectly flagged, causing the control check to fail.

## Testing
Verified that repositories containing a CNAME file now pass the OSPS-QA-05 control check without being incorrectly flagged. Local testing result against the affected repo:
```
2025-08-28T14:25:04.388+0100 [INFO]  OSPS-QA-05.01: No common binary file extensions were found in the repository
```

Fixes #114 