### PR TITLE
test: Add unit tests for splitSpdxExpression function

### DIFF
--- a/evaluation_plans/osps/legal/steps_test.go
+++ b/evaluation_plans/osps/legal/steps_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-
 type FakeGraphqlRepo struct {
 	Repository struct {
 		LicenseInfo struct {
@@ -19,7 +18,7 @@ type FakeGraphqlRepo struct {
 
 func stubGraphqlRepo(licenseUrl string) *data.GraphqlRepoData {
 	repo := &data.GraphqlRepoData{}
-	repo.Repository.LicenseInfo.Url = licenseUrl 
+	repo.Repository.LicenseInfo.Url = licenseUrl
 	return repo
 }
 
@@ -77,6 +76,52 @@ func TestReleasesLicensed(t *testing.T) {
 			result, message := releasesLicensed(test.payloadData, nil)
 			assert.Equal(t, test.expectedResult, result)
 			assert.Equal(t, test.expectedMessage, message)
+		})
+	}
+}
+
+func TestSplitSpdxExpression(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "Single license",
+			input:    "MIT",
+			expected: []string{"MIT"},
+		},
+		{
+			name:     "Simple AND",
+			input:    "MIT AND Apache-2.0",
+			expected: []string{"MIT", "Apache-2.0"},
+		},
+		{
+			name:     "Simple OR",
+			input:    "MIT OR GPL-3.0",
+			expected: []string{"MIT", "GPL-3.0"},
+		},
+		{
+			name:     "Multiple AND",
+			input:    "MIT AND Apache-2.0 AND BSD-3-Clause",
+			expected: []string{"MIT", "Apache-2.0", "BSD-3-Clause"},
+		},
+		{
+			name:     "Mixed AND and OR",
+			input:    "MIT AND Apache-2.0 OR GPL-3.0",
+			expected: []string{"MIT", "Apache-2.0", "GPL-3.0"},
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: []string{""},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := splitSpdxExpression(test.input)
+			assert.Equal(t, test.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
## Overview
Adds comprehensive unit tests for the `splitSpdxExpression` function to ensure reliable SPDX license expression parsing.

## Changes Made
- **Added `TestSplitSpdxExpression`**: Table-driven tests covering essential parsing scenarios
- **Test coverage includes**:
  - Single license identifiers
  - AND operator parsing
  - OR operator parsing  
  - Multiple AND operations
  - Mixed AND/OR expressions
  - Empty string edge case
