### PR TITLE
chore(ci): build against latest stable go version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@v5.4.0
         with:
-          go-version: 1.23
+          go-version: stable # see https://github.com/actions/setup-go/?tab=readme-ov-file#using-stableoldstable-aliases
       - name: build
         run: make build
       - name: test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v5.4.0
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: stable # see https://github.com/actions/setup-go/?tab=readme-ov-file#using-stableoldstable-aliases
       - name: build


### PR DESCRIPTION
This fixes the underlying issue blocking https://github.com/revanite-io/pvtr-github-repo/pull/134 from passing CI