### PR TITLE
fix: remove code check dependency for primary branch protection check

### DIFF
--- a/evaluation_plans/osps/access_control/evaluations.go
+++ b/evaluation_plans/osps/access_control/evaluations.go
@@ -64,7 +64,6 @@ func OSPS_AC_03() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
-			reusable_steps.IsCodeRepo,
 			branchProtectionRestrictsPushes, // This checks branch protection, but not rulesets yet
 		},
 	)

--- a/evaluation_plans/osps/access_control/steps.go
+++ b/evaluation_plans/osps/access_control/steps.go
@@ -27,9 +27,6 @@ func branchProtectionRestrictsPushes(payloadData any, _ map[string]*layer4.Chang
 	if message != "" {
 		return layer4.Unknown, message
 	}
-	if !payload.IsCodeRepo {
-		return layer4.NotApplicable, "Repository contains no code - skipping branch protection checks"
-	}
 	protectionData := payload.Repository.DefaultBranchRef.BranchProtectionRule
 
 	if protectionData.RestrictsPushes {


### PR DESCRIPTION
This change closes issue #141 by updating the evaluation logic to remove any check on what the contents of the repository are.

This change was tested against `revanite-io/example-osps-baseline-level-1` and correctly results in the following result for `AC-03.01`:

```yaml
control-id: OSPS-AC-03
  result: Needs Review
  message: Branch protection rule prevents deletions
  corrupted-state: false
  assessments:
  - requirement-id: OSPS-AC-03.01
    applicability:
    - Maturity Level 1
    - Maturity Level 2
    - Maturity Level 3
    description: When a direct commit is attempted on the project's primary branch, an enforcement mechanism MUST prevent the change from being applied.
    result: Needs Review
    message: Branch protection rule does not restrict pushes or require approving reviews; Rulesets not yet evaluated.
    steps:
    - github.com/revanite-io/pvtr-github-repo/evaluation_plans/osps/access_control.branchProtectionRestrictsPushes
    steps-executed: 1
    start: "2025-09-21T13:02:37-04:00"
    end: "2025-09-21T13:02:37-04:00"
```