### PR TITLE
fix: QA-02.01 to return NeedsReview

### DIFF
--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -217,7 +217,7 @@ func countDependencyManifests(payloadData any) (result layer4.Result, message st
 	if manifestsCount > 0 {
 		return layer4.Passed, fmt.Sprintf("Found %d dependency manifests from GitHub API", manifestsCount)
 	}
-	return layer4.Failed, "No dependency manifests found in the repository by the GitHub API"
+	return layer4.NeedsReview, "No dependency manifests found in the GitHub dependency graph API. Review project to ensure dependencies are managed."
 }
 
 func documentsTestExecution(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {


### PR DESCRIPTION
This change closes issue #145 by updating the evaluation logic to recognize that not all repositories will have enabled the GitHub dependency graph and the setting is not enabled by default.

Therefore, the absence of this data in a repository is not a clearcut failure, but rather a mixed signal. As such, the evaluation now returns NeedsReview rather than Failed in cases where the API indicates no dependency management.

This change was tested with the result:

```yaml
- requirement-id: OSPS-QA-02.01
  applicability:
    - Maturity Level 1
    - Maturity Level 2
    - Maturity Level 3
  description: When the package management system supports it, the source code repository MUST contain a dependency list that accounts for the direct language dependencies.
  result: Needs Review
  message: No dependency manifests found in the GitHub dependency graph API. Review project to ensure dependencies are managed.
  steps:
    - github.com/revanite-io/pvtr-github-repo/evaluation_plans/osps/quality.verifyDependencyManagement
  steps-executed: 1
  start: "2025-09-21T14:09:04-04:00"
  end: "2025-09-21T14:09:04-04:00"
```