### PR TITLE
feat: implement OSPS-VM-03.01 private vulnerability reporting assessment

### DIFF
--- a/evaluation_plans/osps/vuln_management/evaluations.go
+++ b/evaluation_plans/osps/vuln_management/evaluations.go
@@ -63,7 +63,9 @@ func OSPS_VM_03() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
-			reusable_steps.NotImplemented,
+			reusable_steps.IsActive,
+			reusable_steps.HasSecurityInsightsFile,
+			hasPrivateVulnerabilityReporting,
 		},
 	)
 

--- a/evaluation_plans/osps/vuln_management/steps.go
+++ b/evaluation_plans/osps/vuln_management/steps.go
@@ -60,3 +60,26 @@ func hasVulnerabilityDisclosurePolicy(payloadData any, _ map[string]*layer4.Chan
 
 	return layer4.Passed, "Vulnerability disclosure policy was specified in Security Insights data"
 }
+
+func hasPrivateVulnerabilityReporting(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+	data, message := reusable_steps.VerifyPayload(payloadData)
+	if message != "" {
+		return layer4.Unknown, message
+	}
+
+	if !data.Insights.Project.Vulnerability.ReportsAccepted {
+		return layer4.Failed, "Project does not accept vulnerability reports according to Security Insights data"
+	}
+
+	if data.Insights.Project.Vulnerability.Contact.Email != "" {
+		return layer4.Passed, "Private vulnerability reporting available via dedicated contact email in Security Insights data"
+	}
+
+	for _, champion := range data.Insights.Repository.Security.Champions {
+		if champion.Email != "" {
+			return layer4.Passed, "Private vulnerability reporting available via security champions contact in Security Insights data"
+		}
+	}
+
+	return layer4.Failed, "No private vulnerability reporting contact method found in Security Insights data"
+}

--- a/evaluation_plans/osps/vuln_management/steps_test.go
+++ b/evaluation_plans/osps/vuln_management/steps_test.go
@@ -164,3 +164,127 @@ func TestHasVulnerabilityDisclosurePolicy(t *testing.T) {
 		})
 	}
 }
+
+func TestHasPrivateVulnerabilityReporting(t *testing.T) {
+	tests := []struct {
+		name            string
+		payloadData     any
+		expectedResult  layer4.Result
+		expectedMessage string
+	}{
+		{
+			name:            "Private reporting via vulnerability contact email",
+			expectedResult:  layer4.Passed,
+			expectedMessage: "Private vulnerability reporting available via dedicated contact email in Security Insights data",
+			payloadData: data.Payload{
+				RestData: &data.RestData{
+					Insights: si.SecurityInsights{
+						Project: si.Project{
+							Vulnerability: si.VulnReport{
+								ReportsAccepted: true,
+								Contact: si.Contact{
+									Email: "security@example.com",
+								},
+							},
+						},
+					},
+				},
+				GraphqlRepoData: &data.GraphqlRepoData{},
+			},
+		},
+		{
+			name:            "Private reporting via security champions",
+			expectedResult:  layer4.Passed,
+			expectedMessage: "Private vulnerability reporting available via security champions contact in Security Insights data",
+			payloadData: data.Payload{
+				RestData: &data.RestData{
+					Insights: si.SecurityInsights{
+						Project: si.Project{
+							Vulnerability: si.VulnReport{
+								ReportsAccepted: true,
+								Contact: si.Contact{
+									Email: "",
+								},
+							},
+						},
+						Repository: si.Repository{
+							Security: si.SecurityInfo{
+								Champions: []si.Contact{
+									{
+										Name:  "Security Champion",
+										Email: "champion@example.com",
+									},
+								},
+							},
+						},
+					},
+				},
+				GraphqlRepoData: &data.GraphqlRepoData{},
+			},
+		},
+		{
+			name:            "Reports not accepted",
+			expectedResult:  layer4.Failed,
+			expectedMessage: "Project does not accept vulnerability reports according to Security Insights data",
+			payloadData: data.Payload{
+				RestData: &data.RestData{
+					Insights: si.SecurityInsights{
+						Project: si.Project{
+							Vulnerability: si.VulnReport{
+								ReportsAccepted: false,
+								Contact: si.Contact{
+									Email: "security@example.com",
+								},
+							},
+						},
+					},
+				},
+				GraphqlRepoData: &data.GraphqlRepoData{},
+			},
+		},
+		{
+			name:            "No contact methods available",
+			expectedResult:  layer4.Failed,
+			expectedMessage: "No private vulnerability reporting contact method found in Security Insights data",
+			payloadData: data.Payload{
+				RestData: &data.RestData{
+					Insights: si.SecurityInsights{
+						Project: si.Project{
+							Vulnerability: si.VulnReport{
+								ReportsAccepted: true,
+								Contact: si.Contact{
+									Email: "",
+								},
+							},
+						},
+						Repository: si.Repository{
+							Security: si.SecurityInfo{
+								Champions: []si.Contact{
+									{
+										Name:  "Champion Without Email",
+										Email: "",
+									},
+								},
+							},
+						},
+					},
+				},
+				GraphqlRepoData: &data.GraphqlRepoData{},
+			},
+		},
+		{
+			name:            "Invalid payload",
+			expectedResult:  layer4.Unknown,
+			expectedMessage: "Malformed assessment: expected payload type data.Payload, got string (invalid_payload)",
+			payloadData:     "invalid_payload",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, message := hasPrivateVulnerabilityReporting(test.payloadData, nil)
+			assert.Equal(t, test.expectedResult, result)
+			assert.Equal(t, test.expectedMessage, message)
+		})
+	}
+}


### PR DESCRIPTION
- **New function**: `hasPrivateVulnerabilityReporting` checks for private reporting channels
- **Validates** reports accepted + checks for security contact email OR security champions email
- **Tests**: 5 scenarios covering direct email, champions, reports not accepted, no contacts, invalid payload

## Changes
- `evaluation_plans/osps/vuln_management/steps.go`: Add new assessment function
- `evaluation_plans/osps/vuln_management/evaluations.go`: Update OSPS-VM-03.01 assessment steps  
- `evaluation_plans/osps/vuln_management/steps_test.go`: Add comprehensive test coverage

Closes #33