### PR TITLE
feat: Implement OSPS-VM-04.01: Public vulnerability disclosure assessment

### DIFF
--- a/evaluation_plans/osps/vuln_management/evaluations.go
+++ b/evaluation_plans/osps/vuln_management/evaluations.go
@@ -83,7 +83,8 @@ func OSPS_VM_04() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
-			reusable_steps.NotImplemented,
+			reusable_steps.IsActive,
+			hasPublicVulnerabilityDisclosure,
 		},
 	)
 

--- a/evaluation_plans/osps/vuln_management/steps.go
+++ b/evaluation_plans/osps/vuln_management/steps.go
@@ -60,3 +60,20 @@ func hasVulnerabilityDisclosurePolicy(payloadData any, _ map[string]*layer4.Chan
 
 	return layer4.Passed, "Vulnerability disclosure policy was specified in Security Insights data"
 }
+
+func hasPublicVulnerabilityDisclosure(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+	data, message := reusable_steps.VerifyPayload(payloadData)
+	if message != "" {
+		return layer4.Unknown, message
+	}
+
+	if data.GraphqlRepoData.Repository.IsSecurityPolicyEnabled {
+		return layer4.Passed, "Public vulnerability disclosure available via GitHub security policy"
+	}
+
+	if data.Insights.Project.Vulnerability.SecurityPolicy != "" {
+		return layer4.Passed, "Public vulnerability disclosure available via security policy in Security Insights data"
+	}
+
+	return layer4.Failed, "No public vulnerability disclosure mechanism found"
+}


### PR DESCRIPTION
Implements OSPS-VM-04.01 to check if projects publicly publish vulnerability data.

**Changes:**
- Add `hasPublicVulnerabilityDisclosure` function
- Update OSPS-VM-04.01 assessment steps: `IsActive` + `hasPublicVulnerabilityDisclosure`
- Add 5 comprehensive test cases

Closes #34