### PR TITLE
feat: add support for sarif output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/goccy/go-yaml v1.18.0
 	github.com/google/go-github/v74 v74.0.0
 	github.com/migueleliasweb/go-github-mock v1.4.0
-	github.com/ossf/gemara v0.9.0
+	github.com/ossf/gemara v0.10.1
 	github.com/ossf/si-tooling/v2 v2.0.5-0.20250508212737-7ddcc8c43db9
-	github.com/privateerproj/privateer-sdk v1.5.0
+	github.com/privateerproj/privateer-sdk v1.6.0
 	github.com/rhysd/actionlint v1.7.7
 	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7
 	golang.org/x/oauth2 v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/migueleliasweb/go-github-mock v1.4.0 h1:pQ6K8r348m2q79A8Khb0PbEeNQV7t
 github.com/migueleliasweb/go-github-mock v1.4.0/go.mod h1:/DUmhXkxrgVlDOVBqGoUXkV4w0ms5n1jDQHotYm135o=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/ossf/gemara v0.9.0 h1:3cno4WRKGgYR7LiCGyu86Uxljaon6uqvjZ2CE33nnL0=
-github.com/ossf/gemara v0.9.0/go.mod h1:+cvFp/ufYvvhWXp1MRHwsFYgUKM9uDEDFxyZNm30H7g=
+github.com/ossf/gemara v0.10.1 h1:rvM8s/dAqF0QkCtztwgx92o/hWukRdS4rzsTpRT9chY=
+github.com/ossf/gemara v0.10.1/go.mod h1:FRRem1gQ9m+c3QiBLN/PkL/RfzyNpF3aO7AWqZVzerg=
 github.com/ossf/si-tooling/v2 v2.0.5-0.20250508212737-7ddcc8c43db9 h1:H8zbVnZ1dbVhoQVGZanbDOSOX91KiCSsge4+GLrcFms=
 github.com/ossf/si-tooling/v2 v2.0.5-0.20250508212737-7ddcc8c43db9/go.mod h1:I7UDEAfNwoT2iwZrvORukgkGLKeD/cgVhHtcLPpaS6c=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
@@ -84,8 +84,8 @@ github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/privateerproj/privateer-sdk v1.5.0 h1:A39S/J1RaAEKCPrLVwivdmF2CK6iGpfkgXJX3D22q4U=
-github.com/privateerproj/privateer-sdk v1.5.0/go.mod h1:rk8NNfEpCLabEgHHyuZsuiFefHSvEyQHEI1xMpHjMPE=
+github.com/privateerproj/privateer-sdk v1.6.0 h1:lljDUiesQEhgSH/6ZX+LRu+DeJPj1wHBJUAj+A6PAbc=
+github.com/privateerproj/privateer-sdk v1.6.0/go.mod h1:jNQQqTxvEnQBvR/BuRrbxMt8wxe7fX6mOC7PBTYknVI=
 github.com/rhysd/actionlint v1.7.7 h1:0KgkoNTrYY7vmOCs9BW2AHxLvvpoY9nEUzgBHiPUr0k=
 github.com/rhysd/actionlint v1.7.7/go.mod h1:AE6I6vJEkNaIfWqC2GNE5spIJNhxf8NCtLEKU4NnUXg=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/main.go
+++ b/main.go
@@ -37,6 +37,8 @@ func main() {
 	}
 
 	pvtrVessel := pluginkit.NewEvaluationOrchestrator(PluginName, nil, RequiredVars)
+	pvtrVessel.PluginVersion = Version
+	pvtrVessel.PluginUri = "github.com/revanite-io/pvtr-github-repo"
 
 	requirements, err := baseline.GetAssessmentRequirements()
 	if err != nil {


### PR DESCRIPTION
<details><summary>example:</summary>

```
{"$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/123e95847b13fbdd4cbe2120fa5e33355d4a042b/Schemata/sarif-schema-2.1.0.json","version":"2.1.0","runs":[{"tool":{"driver":{"name":"","rules":[{"id":"OSPS-AC-01/OSPS-AC-01.01","name":"When a user attempts to access a sensitive resource in the project's version control system, the system MUST require the user to complete a multi-factor authentication process."},{"id":"OSPS-AC-02/OSPS-AC-02.01","name":"When a new collaborator is added, the version control system MUST require manual permission assignment, or restrict the collaborator permissions to the lowest available privileges by default."},{"id":"OSPS-AC-03/OSPS-AC-03.01","name":"When a direct commit is attempted on the project's primary branch, an enforcement mechanism MUST prevent the change from being applied."},{"id":"OSPS-AC-03/OSPS-AC-03.02","name":"When an attempt is made to delete the project's primary branch, the version control system MUST treat this as a sensitive activity and require explicit confirmation of intent."},{"id":"OSPS-AC-04/OSPS-AC-04.01","name":"When a CI/CD task is executed with no permissions specified, the project's version control system MUST default to the lowest available permissions for all activities in the pipeline."},{"id":"OSPS-BR-01/OSPS-BR-01.01","name":"When a CI/CD pipeline accepts an input parameter, that parameter MUST be sanitized and validated prior to use in the pipeline."},{"id":"OSPS-BR-01/OSPS-BR-01.02","name":"When a CI/CD pipeline uses a branch name in its functionality, that name value MUST be sanitized and validated prior to use in the pipeline."},{"id":"OSPS-BR-02/OSPS-BR-02.01","name":"When an official release is created, that release MUST be assigned a unique version identifier."},{"id":"OSPS-BR-03/OSPS-BR-03.01","name":"When the project lists a URI as an official project channel, that URI MUST be exclusively delivered using encrypted channels."},{"id":"OSPS-BR-03/OSPS-BR-03.02","name":"When the project lists a URI as an official distribution channel, that URI MUST be exclusively delivered using encrypted channels."},{"id":"OSPS-BR-04/OSPS-BR-04.01","name":"When an official release is created, that release MUST contain a descriptive log of functional and security modifications."},{"id":"OSPS-BR-05/OSPS-BR-05.01","name":"When a build and release pipeline ingests dependencies, it MUST use standardized tooling where available."},{"id":"OSPS-BR-06/OSPS-BR-06.01","name":"When an official release is created, that release MUST be signed or accounted for in a signed manifest including each asset's cryptographic hashes."},{"id":"OSPS-DO-01/OSPS-DO-01.01","name":"When the project has made a release, the project documentation MUST include user guides for all basic functionality."},{"id":"OSPS-DO-02/OSPS-DO-02.01","name":"When the project has made a release, the project documentation MUST include a guide for reporting defects."},{"id":"OSPS-DO-03/OSPS-DO-03.01","name":"When the project has made a release, the project documentation MUST contain instructions to verify the integrity and authenticity of the release assets."},{"id":"OSPS-DO-03/OSPS-DO-03.02","name":"When the project has made a release, the project documentation MUST contain instructions to verify the expected identity of the person or process authoring the software release."},{"id":"OSPS-DO-04/OSPS-DO-04.01","name":"When the project has made a release, the project documentation MUST include a descriptive statement about the scope and duration of support for each release."},{"id":"OSPS-DO-05/OSPS-DO-05.01","name":"When the project has made a release, the project documentation MUST provide a descriptive statement when releases or versions will no longer receive security updates."},{"id":"OSPS-DO-06/OSPS-DO-06.01","name":"When the project has made a release, the project documentation MUST include a description of how the project selects, obtains, and tracks its dependencies."},{"id":"OSPS-GV-01/OSPS-GV-01.01","name":"While active, the project documentation MUST include a list of project members with access to sensitive resources."},{"id":"OSPS-GV-01/OSPS-GV-01.02","name":"While active, the project documentation MUST include descriptions of the roles and responsibilities for members of the project."},{"id":"OSPS-GV-02/OSPS-GV-02.01","name":"While active, the project MUST have one or more mechanisms for public discussions about proposed changes and usage obstacles."},{"id":"OSPS-GV-03/OSPS-GV-03.01","name":"While active, the project documentation MUST include an explanation of the contribution process."},{"id":"OSPS-GV-03/OSPS-GV-03.02","name":"While active, the project documentation MUST include a guide for code contributors that includes requirements for acceptable contributions."},{"id":"OSPS-GV-04/OSPS-GV-04.01","name":"While active, the project documentation MUST have a policy that code contributors are reviewed prior to granting escalated permissions to sensitive resources."},{"id":"OSPS-LE-01/OSPS-LE-01.01","name":"While active, the version control system MUST require all code contributors to assert that they are legally authorized to make the associated contributions on every commit."},{"id":"OSPS-LE-02/OSPS-LE-02.01","name":"While active, the license for the source code MUST meet the OSI Open Source Definition or the FSF Free Software Definition."},{"id":"OSPS-LE-02/OSPS-LE-02.02","name":"While active, the license for the released software assets MUST meet the OSI Open Source Definition or the FSF Free Software Definition."},{"id":"OSPS-LE-03/OSPS-LE-03.01","name":"While active, the license for the source code MUST be maintained in the corresponding repository's LICENSE file, COPYING file, or LICENSE/ directory."},{"id":"OSPS-LE-03/OSPS-LE-03.02","name":"While active, the license for the released software assets MUST be included in the released source code, or in a LICENSE file, COPYING file, or LICENSE/ directory alongside the corresponding release assets."},{"id":"OSPS-QA-01/OSPS-QA-01.01","name":"While active, the project's source code repository MUST be publicly readable at a static URL."},{"id":"OSPS-QA-01/OSPS-QA-01.02","name":"The version control system MUST contain a publicly readable record of all changes made, who made the changes, and when the changes were made."},{"id":"OSPS-QA-02/OSPS-QA-02.01","name":"When the package management system supports it, the source code repository MUST contain a dependency list that accounts for the direct language dependencies."},{"id":"OSPS-QA-02/OSPS-QA-02.02","name":"When the project has made a release, all compiled released software assets MUST be delivered with a software bill of materials."},{"id":"OSPS-QA-03/OSPS-QA-03.01","name":"When a commit is made to the primary branch, any automated status checks for commits MUST pass or be manually bypassed."},{"id":"OSPS-QA-04/OSPS-QA-04.01","name":"While active, the project documentation MUST contain a list of any codebases that are considered subprojects or additional repositories."},{"id":"OSPS-QA-05/OSPS-QA-05.01","name":"While active, the version control system MUST NOT contain generated executable artifacts."},{"id":"OSPS-QA-06/OSPS-QA-06.01","name":"Prior to a commit being accepted, the project's CI/CD pipelines MUST run at least one automated test suite to ensure the changes meet expectations."},{"id":"OSPS-QA-06/OSPS-QA-06.02","name":"While active, project's documentation MUST clearly document when and how tests are run."},{"id":"OSPS-QA-06/OSPS-QA-06.03","name":"While active, the project's documentation MUST include a policy that all major changes to the software produced by the project should add or update tests of the functionality in an automated test suite."},{"id":"OSPS-QA-07/OSPS-QA-07.01","name":"When a commit is made to the primary branch, the project's version control system MUST require at least one non-author approval of the changes before merging."},{"id":"OSPS-SA-01/OSPS-SA-01.01","name":"When the project has made a release, the project documentation MUST include design documentation demonstrating all actions and actors within the system."},{"id":"OSPS-SA-02/OSPS-SA-02.01","name":"When the project has made a release, the project documentation MUST include descriptions of all external software interfaces of the released software assets."},{"id":"OSPS-SA-03/OSPS-SA-03.01","name":"When the project has made a release, the project MUST perform a security assessment to understand the most likely and impactful potential security problems that could occur within the software."},{"id":"OSPS-SA-03/OSPS-SA-03.02","name":"When the project has made a release, the project MUST perform a threat modeling and attack surface analysis to understand and protect against attacks on critical code paths, functions, and interactions within the system."},{"id":"OSPS-VM-01/OSPS-VM-01.01","name":"While active, the project documentation MUST include a policy for coordinated vulnerability reporting, with a clear timeframe for response."},{"id":"OSPS-VM-02/OSPS-VM-02.01","name":"While active, the project documentation MUST contain security contacts."},{"id":"OSPS-VM-03/OSPS-VM-03.01","name":"While active, the project documentation MUST provide a means for reporting security vulnerabilities privately to the security contacts within the project."},{"id":"OSPS-VM-04/OSPS-VM-04.01","name":"While active, the project documentation MUST publicly publish data about discovered vulnerabilities."},{"id":"OSPS-VM-04/OSPS-VM-04.02","name":"While active, any vulnerabilities in the software components not affecting the project MUST be accounted for in a VEX document, augmenting the vulnerability report with non-exploitability details."},{"id":"OSPS-VM-05/OSPS-VM-05.01","name":"While active, the project documentation MUST include a policy that defines a threshold for remediation of SCA findings related to vulnerabilities and licenses."},{"id":"OSPS-VM-05/OSPS-VM-05.02","name":"While active, the project documentation MUST include a policy to address SCA violations prior to any release."},{"id":"OSPS-VM-05/OSPS-VM-05.03","name":"While active, all changes to the project's codebase MUST be automatically evaluated against a documented policy for malicious dependencies and known vulnerabilities in dependencies, then blocked in the event of violations, except when declared and suppressed as non-exploitable."},{"id":"OSPS-VM-06/OSPS-VM-06.01","name":"While active, the project documentation MUST include a policy that defines a threshold for remediation of SAST findings."},{"id":"OSPS-VM-06/OSPS-VM-06.02","name":"While active, all changes to the project's codebase MUST be automatically evaluated against a documented policy for security weaknesses and blocked in the event of violations except when declared and suppressed as non-exploitable."}]}},"results":[{"ruleId":"OSPS-AC-01/OSPS-AC-01.01","level":"warning","message":{"text":"Not evaluated. Two-factor authentication evaluation requires a token with org:admin permissions, or manual review"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-AC-01/OSPS-AC-01.01"}]}]},{"ruleId":"OSPS-AC-02/OSPS-AC-02.01","level":"note","message":{"text":"This control is enforced by GitHub for all projects"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-AC-02/OSPS-AC-02.01"}]}]},{"ruleId":"OSPS-AC-03/OSPS-AC-03.01","level":"warning","message":{"text":"Branch protection rule does not restrict pushes or require approving reviews; Rulesets not yet evaluated."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-AC-03/OSPS-AC-03.01"}]}]},{"ruleId":"OSPS-AC-03/OSPS-AC-03.02","level":"note","message":{"text":"Branch protection rule prevents deletions"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-AC-03/OSPS-AC-03.02"}]}]},{"ruleId":"OSPS-AC-04/OSPS-AC-04.01","level":"note","message":{"text":"When a CI/CD task is executed with no permissions specified, the project's version control system MUST default to the lowest available permissions for all activities in the pipeline."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-AC-04/OSPS-AC-04.01"}]}]},{"ruleId":"OSPS-BR-01/OSPS-BR-01.01","level":"note","message":{"text":"GitHub Workflows variables do not contain untrusted inputs"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-BR-01/OSPS-BR-01.01"}]}]},{"ruleId":"OSPS-BR-01/OSPS-BR-01.02","level":"warning","message":{"text":"Not implemented"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-BR-01/OSPS-BR-01.02"}]}]},{"ruleId":"OSPS-BR-02/OSPS-BR-02.01","level":"note","message":{"text":"When an official release is created, that release MUST be assigned a unique version identifier."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-BR-02/OSPS-BR-02.01"}]}]},{"ruleId":"OSPS-BR-03/OSPS-BR-03.01","level":"warning","message":{"text":"All links use HTTPS"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-BR-03/OSPS-BR-03.01"}]}]},{"ruleId":"OSPS-BR-03/OSPS-BR-03.02","level":"note","message":{"text":"No official distribution points found in Security Insights data"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-BR-03/OSPS-BR-03.02"}]}]},{"ruleId":"OSPS-BR-04/OSPS-BR-04.01","level":"note","message":{"text":"When an official release is created, that release MUST contain a descriptive log of functional and security modifications."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-BR-04/OSPS-BR-04.01"}]}]},{"ruleId":"OSPS-BR-05/OSPS-BR-05.01","level":"note","message":{"text":"When a build and release pipeline ingests dependencies, it MUST use standardized tooling where available."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-BR-05/OSPS-BR-05.01"}]}]},{"ruleId":"OSPS-BR-06/OSPS-BR-06.01","level":"note","message":{"text":"When an official release is created, that release MUST be signed or accounted for in a signed manifest including each asset's cryptographic hashes."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-BR-06/OSPS-BR-06.01"}]}]},{"ruleId":"OSPS-DO-01/OSPS-DO-01.01","level":"error","message":{"text":"User guide was NOT specified in Security Insights data"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-DO-01/OSPS-DO-01.01"}]}]},{"ruleId":"OSPS-DO-02/OSPS-DO-02.01","level":"error","message":{"text":"Both issues and discussions are disabled for the repository"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-DO-02/OSPS-DO-02.01"}]}]},{"ruleId":"OSPS-DO-03/OSPS-DO-03.01","level":"note","message":{"text":"When the project has made a release, the project documentation MUST contain instructions to verify the integrity and authenticity of the release assets."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-DO-03/OSPS-DO-03.01"}]}]},{"ruleId":"OSPS-DO-03/OSPS-DO-03.02","level":"note","message":{"text":"When the project has made a release, the project documentation MUST contain instructions to verify the expected identity of the person or process authoring the software release."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-DO-03/OSPS-DO-03.02"}]}]},{"ruleId":"OSPS-DO-04/OSPS-DO-04.01","level":"note","message":{"text":"When the project has made a release, the project documentation MUST include a descriptive statement about the scope and duration of support for each release."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-DO-04/OSPS-DO-04.01"}]}]},{"ruleId":"OSPS-DO-05/OSPS-DO-05.01","level":"note","message":{"text":"When the project has made a release, the project documentation MUST provide a descriptive statement when releases or versions will no longer receive security updates."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-DO-05/OSPS-DO-05.01"}]}]},{"ruleId":"OSPS-DO-06/OSPS-DO-06.01","level":"note","message":{"text":"When the project has made a release, the project documentation MUST include a description of how the project selects, obtains, and tracks its dependencies."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-DO-06/OSPS-DO-06.01"}]}]},{"ruleId":"OSPS-GV-01/OSPS-GV-01.01","level":"note","message":{"text":"While active, the project documentation MUST include a list of project members with access to sensitive resources."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-GV-01/OSPS-GV-01.01"}]}]},{"ruleId":"OSPS-GV-01/OSPS-GV-01.02","level":"note","message":{"text":"While active, the project documentation MUST include descriptions of the roles and responsibilities for members of the project."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-GV-01/OSPS-GV-01.02"}]}]},{"ruleId":"OSPS-GV-02/OSPS-GV-02.01","level":"error","message":{"text":"Both issues and discussions are disabled for the repository"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-GV-02/OSPS-GV-02.01"}]}]},{"ruleId":"OSPS-GV-03/OSPS-GV-03.01","level":"warning","message":{"text":"Contributing guide was found via GitHub API (Recommendation: Add code of conduct location to Security Insights data)"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-GV-03/OSPS-GV-03.01"}]}]},{"ruleId":"OSPS-GV-03/OSPS-GV-03.02","level":"note","message":{"text":"While active, the project documentation MUST include a guide for code contributors that includes requirements for acceptable contributions."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-GV-03/OSPS-GV-03.02"}]}]},{"ruleId":"OSPS-GV-04/OSPS-GV-04.01","level":"note","message":{"text":"While active, the project documentation MUST have a policy that code contributors are reviewed prior to granting escalated permissions to sensitive resources."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-GV-04/OSPS-GV-04.01"}]}]},{"ruleId":"OSPS-LE-01/OSPS-LE-01.01","level":"note","message":{"text":"While active, the version control system MUST require all code contributors to assert that they are legally authorized to make the associated contributions on every commit."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-LE-01/OSPS-LE-01.01"}]}]},{"ruleId":"OSPS-LE-02/OSPS-LE-02.01","level":"warning","message":{"text":"All license found are OSI or FSF approved"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-LE-02/OSPS-LE-02.01"}]}]},{"ruleId":"OSPS-LE-02/OSPS-LE-02.02","level":"warning","message":{"text":"All license found are OSI or FSF approved"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-LE-02/OSPS-LE-02.02"}]}]},{"ruleId":"OSPS-LE-03/OSPS-LE-03.01","level":"note","message":{"text":"License was found in a well known location via the GitHub API"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-LE-03/OSPS-LE-03.01"}]}]},{"ruleId":"OSPS-LE-03/OSPS-LE-03.02","level":"note","message":{"text":"No releases found"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-LE-03/OSPS-LE-03.02"}]}]},{"ruleId":"OSPS-QA-01/OSPS-QA-01.01","level":"note","message":{"text":"Repository is public"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-QA-01/OSPS-QA-01.01"}]}]},{"ruleId":"OSPS-QA-01/OSPS-QA-01.02","level":"note","message":{"text":"This control is enforced by GitHub for all projects"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-QA-01/OSPS-QA-01.02"}]}]},{"ruleId":"OSPS-QA-02/OSPS-QA-02.01","level":"warning","message":{"text":"No dependency manifests found in the GitHub dependency graph API. Review project to ensure dependencies are managed."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-QA-02/OSPS-QA-02.01"}]}]},{"ruleId":"OSPS-QA-02/OSPS-QA-02.02","level":"note","message":{"text":"When the project has made a release, all compiled released software assets MUST be delivered with a software bill of materials."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-QA-02/OSPS-QA-02.02"}]}]},{"ruleId":"OSPS-QA-03/OSPS-QA-03.01","level":"note","message":{"text":"When a commit is made to the primary branch, any automated status checks for commits MUST pass or be manually bypassed."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-QA-03/OSPS-QA-03.01"}]}]},{"ruleId":"OSPS-QA-04/OSPS-QA-04.01","level":"error","message":{"text":"Insights does not contain a list of repositories"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-QA-04/OSPS-QA-04.01"}]}]},{"ruleId":"OSPS-QA-05/OSPS-QA-05.01","level":"note","message":{"text":"No common binary file extensions were found in the repository"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-QA-05/OSPS-QA-05.01"}]}]},{"ruleId":"OSPS-QA-06/OSPS-QA-06.01","level":"note","message":{"text":"Prior to a commit being accepted, the project's CI/CD pipelines MUST run at least one automated test suite to ensure the changes meet expectations."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-QA-06/OSPS-QA-06.01"}]}]},{"ruleId":"OSPS-QA-06/OSPS-QA-06.02","level":"note","message":{"text":"While active, project's documentation MUST clearly document when and how tests are run."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-QA-06/OSPS-QA-06.02"}]}]},{"ruleId":"OSPS-QA-06/OSPS-QA-06.03","level":"note","message":{"text":"While active, the project's documentation MUST include a policy that all major changes to the software produced by the project should add or update tests of the functionality in an automated test suite."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-QA-06/OSPS-QA-06.03"}]}]},{"ruleId":"OSPS-QA-07/OSPS-QA-07.01","level":"note","message":{"text":"When a commit is made to the primary branch, the project's version control system MUST require at least one non-author approval of the changes before merging."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-QA-07/OSPS-QA-07.01"}]}]},{"ruleId":"OSPS-SA-01/OSPS-SA-01.01","level":"note","message":{"text":"When the project has made a release, the project documentation MUST include design documentation demonstrating all actions and actors within the system."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-SA-01/OSPS-SA-01.01"}]}]},{"ruleId":"OSPS-SA-02/OSPS-SA-02.01","level":"note","message":{"text":"When the project has made a release, the project documentation MUST include descriptions of all external software interfaces of the released software assets."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-SA-02/OSPS-SA-02.01"}]}]},{"ruleId":"OSPS-SA-03/OSPS-SA-03.01","level":"note","message":{"text":"When the project has made a release, the project MUST perform a security assessment to understand the most likely and impactful potential security problems that could occur within the software."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-SA-03/OSPS-SA-03.01"}]}]},{"ruleId":"OSPS-SA-03/OSPS-SA-03.02","level":"note","message":{"text":"When the project has made a release, the project MUST perform a threat modeling and attack surface analysis to understand and protect against attacks on critical code paths, functions, and interactions within the system."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-SA-03/OSPS-SA-03.02"}]}]},{"ruleId":"OSPS-VM-01/OSPS-VM-01.01","level":"note","message":{"text":"While active, the project documentation MUST include a policy for coordinated vulnerability reporting, with a clear timeframe for response."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-VM-01/OSPS-VM-01.01"}]}]},{"ruleId":"OSPS-VM-02/OSPS-VM-02.01","level":"error","message":{"text":"Security contacts were not specified in Security Insights data"},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-VM-02/OSPS-VM-02.01"}]}]},{"ruleId":"OSPS-VM-03/OSPS-VM-03.01","level":"note","message":{"text":"While active, the project documentation MUST provide a means for reporting security vulnerabilities privately to the security contacts within the project."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-VM-03/OSPS-VM-03.01"}]}]},{"ruleId":"OSPS-VM-04/OSPS-VM-04.01","level":"note","message":{"text":"While active, the project documentation MUST publicly publish data about discovered vulnerabilities."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-VM-04/OSPS-VM-04.01"}]}]},{"ruleId":"OSPS-VM-04/OSPS-VM-04.02","level":"note","message":{"text":"While active, any vulnerabilities in the software components not affecting the project MUST be accounted for in a VEX document, augmenting the vulnerability report with non-exploitability details."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-VM-04/OSPS-VM-04.02"}]}]},{"ruleId":"OSPS-VM-05/OSPS-VM-05.01","level":"note","message":{"text":"While active, the project documentation MUST include a policy that defines a threshold for remediation of SCA findings related to vulnerabilities and licenses."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-VM-05/OSPS-VM-05.01"}]}]},{"ruleId":"OSPS-VM-05/OSPS-VM-05.02","level":"note","message":{"text":"While active, the project documentation MUST include a policy to address SCA violations prior to any release."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-VM-05/OSPS-VM-05.02"}]}]},{"ruleId":"OSPS-VM-05/OSPS-VM-05.03","level":"note","message":{"text":"While active, all changes to the project's codebase MUST be automatically evaluated against a documented policy for malicious dependencies and known vulnerabilities in dependencies, then blocked in the event of violations, except when declared and suppressed as non-exploitable."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-VM-05/OSPS-VM-05.03"}]}]},{"ruleId":"OSPS-VM-06/OSPS-VM-06.01","level":"note","message":{"text":"While active, the project documentation MUST include a policy that defines a threshold for remediation of SAST findings."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-VM-06/OSPS-VM-06.01"}]}]},{"ruleId":"OSPS-VM-06/OSPS-VM-06.02","level":"note","message":{"text":"While active, all changes to the project's codebase MUST be automatically evaluated against a documented policy for security weaknesses and blocked in the event of violations except when declared and suppressed as non-exploitable."},"locations":[{"logicalLocations":[{"fullyQualifiedName":"OSPS-VM-06/OSPS-VM-06.02"}]}]}]}]}
```

</details>