### PR TITLE
feat(ci): attest release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,9 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     permissions:
+      attestations: write
       contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -39,3 +41,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-checksums: dist/checksums.txt

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,6 +42,9 @@ changelog:
       - "^docs:"
       - "^test:"
 
+checksum:
+  name_template: "checksums.txt"
+
 release:
   prerelease: auto
 


### PR DESCRIPTION
This change configures `goreleaser` to write artifact digests to a consistent path: `dist/checksums.txt` and adds the `actions/attest-build-provenance@v3` action to our release workflow so all released artifacts have provenance attestations.

I'm not entirely how best to test these changes so hoping I can get some guidance from @jmeridth 