### PR TITLE
feat(ci): add sbom generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
       attestations: write
       contents: write
       id-token: write
+    outputs:
+      attestation_matrix: ${{ steps.generate_matrix.outputs.matrix }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -33,6 +35,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.23.4
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@f8bdd1d8ac5e901a77a92f111440fdb1b593736b
+        with:
+          syft-version: v1.33.0
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a
         with:
@@ -45,3 +51,32 @@ jobs:
         uses: actions/attest-build-provenance@v3
         with:
           subject-checksums: dist/checksums.txt
+      - name: Generate attestation matrix
+        id: generate_matrix
+        run: |
+          matrix=$(ls dist/*.spdx.json | jq -R '{"sbom": ., "archive": sub("\\.spdx\\.json$"; "")}' | jq -s -c '{"include": .}')
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+      - name: Upload artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: dist
+          path: dist
+  attest-sboms:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      id-token: write
+    strategy:
+      matrix: ${{ fromJson(needs.goreleaser.outputs.attestation_matrix) }}
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+        with:
+          name: dist
+          path: dist
+      - name: Attest SBOM
+        uses: actions/attest-sbom@4651f806c01d8637787e274ac3bdf724ef169f34
+        with:
+          subject-path: "${{ matrix.archive }}"
+          sbom-path: "${{ matrix.sbom }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,5 +48,60 @@ checksum:
 release:
   prerelease: auto
 
+sboms:
+  - # ID of the sbom config, must be unique.
+    #
+    # Default: 'default'.
+    id: sboms
+
+    # List of names of the SBOM documents created at this step
+    # (relative to the dist dir).
+    #
+    # Each element configured is made available as variables. For example:
+    #   documents: ["foo", "bar"]
+    #
+    # would make the following variables that can be referenced as template keys:
+    #   document0: "foo"
+    #   document1: "bar"
+    #
+    # Note that multiple sbom values are only allowed if the value of
+    # "artifacts" is "any".
+    #
+    # Default:
+    #   When "binary":   ["{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.sbom.json"]
+    #   When "any":      []
+    #   Otherwise:       ["{{ .ArtifactName }}.sbom.json"]
+    # Templates: allowed.
+    documents:
+      - "${artifact}.spdx.json"
+
+    # Path to the SBOM generator command
+    #
+    # Note: the process CWD will be set to the same location as "dist"
+    #
+    # Default: 'syft'.
+    cmd: syft
+
+    # Command line arguments for the command
+    #
+    # Default: ["$artifact", "--output", "spdx-json=$document", "--enrich", "all"].
+    # Templates: allowed.
+    # args: ["$artifact", "--output", "cyclonedx-json=$document"]
+
+    # Which artifacts to catalog.
+    #
+    # Valid options are:
+    # - any:        let the SBOM tool decide which artifacts available in
+    #               the cwd should be cataloged
+    # - source:     source archive
+    # - package:    Linux packages (deb, rpm, apk, etc)
+    # - installer:  Windows MSI installers (Pro only)
+    # - diskimage:  macOS DMG disk images (Pro only)
+    # - archive:    archives from archive pipe
+    # - binary:     binaries output from the build stage
+    #
+    # Default: 'archive'.
+    artifacts: archive
+
 universal_binaries:
   - replace: true


### PR DESCRIPTION
This change adds generation of SPDX JSON format SBOMs for all release archives created. The SBOMs are then included as subjects in the release workflow attestation.

Attestations produced during testing: https://github.com/trumant/pvtr-github-repo/attestations

Note that provenance attestations are made for all archives and sboms in https://github.com/trumant/pvtr-github-repo/attestations/11257519 and then separately, SBOM attestations are made for each SBOM, example: https://github.com/trumant/pvtr-github-repo/attestations/11257575
